### PR TITLE
Remove titles and comments from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ffmpeg
 youtube-dl
 scipy
 audiotsm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
-Command Line Programs
------
 ffmpeg
-youtube-dl (optional)
-
-External Python Libraries
------
+youtube-dl
 scipy
 audiotsm
 opencv-python


### PR DESCRIPTION
By removing titles and comments, you are able to run `pip install -r requirements.txt` to install all the necessary dependencies automatically. (see https://pip.pypa.io/en/stable/user_guide/#requirements-files for more information).  
Otherwise, pip throws an error: `ERROR: Invalid requirement: 'Command Line Programs' (from line 1 of requirements.txt)`