### PR TITLE
Use correct extension handling

### DIFF
--- a/auto_editor/edit.py
+++ b/auto_editor/edit.py
@@ -99,7 +99,7 @@ def edit_media(i, inp, ffmpeg, args, progress, segment, exporting_to_editor, dat
         output_path = set_output_name(inp.path, inp.ext, data_file, args)
     else:
         output_path = args.output_file[i]
-        if(not os.path.isdir(inp.path) and '.' not in output_path):
+        if(not os.path.isdir(inp.path) and os.path.splitext(output_path)[1] == ''):
             output_path = set_output_name(output_path, inp.ext, data_file, args)
 
     log.debug('{} -> {}'.format(inp.path, output_path))


### PR DESCRIPTION
there was an edge case when using local relative path (e.g. ".\SomeFolder\file")

fix tested on
* windows 11 64 bit python 3.10.1
* wsl Ubuntu 20.04.3 LTS 64 bit python 3.8.10

the test folder setup was
* folder/
  * video.mp4
  * tmp/
    * empty

the command ran (where `pwd` is `folder`):
```bash
auto-editor ./video.mp4 --no_open -o ./tmp/hey
```

before the fix an error will be received:
```
Error! The file ./tmp/hey was not created.

Something went wrong!
Create a bug report at:
  https://github.com/WyattBlue/auto-editor/issues/
```
after the whole operation logs appear correctly

this is caused because the check `'.' not in output_path` will find the `.` of the current directory and act as if `output_path` is a directory for a file with extension, which is not the case
so I replaced the check with `os.path.splitext` so that it will check the existence of an extension correctly