### PR TITLE
Fix a bug

### DIFF
--- a/auto_editor/render/audio.py
+++ b/auto_editor/render/audio.py
@@ -46,7 +46,8 @@ def make_new_audio(
             writer = ArrWriter(np.zeros((0, 2), dtype=np.int16))
 
             phasevocoder(2, speed=the_speed).run(reader, writer)
-            main_writer.writeframes(writer.output)
+            if writer.output.shape[0]!=0:
+                main_writer.writeframes(writer.output)
 
         progress.tick(c)
     progress.end()


### PR DESCRIPTION
If the speed is so fast that the length of audio is 0, an ERROR will be occurred like this:

Traceback (most recent call last):
  File "F:\ProgramData\Anaconda3\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "F:\ProgramData\Anaconda3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "F:\ProgramData\Anaconda3\Scripts\auto-editor.exe\__main__.py", line 7, in <module>
  File "F:\ProgramData\Anaconda3\lib\site-packages\auto_editor\__main__.py", line 423, in main
    main_loop(input_list, ffmpeg, args, log)
  File "F:\ProgramData\Anaconda3\lib\site-packages\auto_editor\__main__.py", line 403, in main_loop
    cuts, output_path = edit_media(i, inp, ffmpeg, args, progress, TEMP, log)
  File "F:\ProgramData\Anaconda3\lib\site-packages\auto_editor\edit.py", line 248, in edit_media
    make_media(inp, chunks, output_path)
  File "F:\ProgramData\Anaconda3\lib\site-packages\auto_editor\edit.py", line 216, in make_media
    make_new_audio(temp_file, new_file, chunks, log, fps, progress)
  File "F:\ProgramData\Anaconda3\lib\site-packages\auto_editor\render\audio.py", line 51, in make_new_audio
    main_writer.writeframes(writer.output)
  File "F:\ProgramData\Anaconda3\lib\wave.py", line 437, in writeframes
    self.writeframesraw(data)
  File "F:\ProgramData\Anaconda3\lib\wave.py", line 425, in writeframesraw
    data = memoryview(data).cast('B')
TypeError: memoryview: cannot cast view with zeros in shape or strides