### PR TITLE
Change video bitrate from 10m to 10M

### DIFF
--- a/auto_editor/utils/types.py
+++ b/auto_editor/utils/types.py
@@ -247,7 +247,7 @@ class Args:
     yt_dlp_extras: str | None = None
     video_codec: str = "auto"
     audio_codec: str = "auto"
-    video_bitrate: str = "10m"
+    video_bitrate: str = "10M"
     audio_bitrate: str = "unset"
     video_quality_scale: str = "unset"
     scale: float = 1.0


### PR DESCRIPTION
Per [ffmpeg Documentation](https://www.ffmpeg.org/ffmpeg-all.html#Expression-Evaluation)

> "m" = 10^-3
> "M" = 10^6

Implicitly corresponding to micro and Mega, respectively.

Using [FFmpeg's debug report](https://www.ffmpeg.org/ffmpeg-all.html#Generic-options), when the video bitrate is 10m (`-b:v 10m`), the report includes the following

> iTargetBitrate= 2000000;iMaxBitrate= 0;
> .iSpatialBitrate= 2000000; .iMaxSpatialBitrate= 0; 
> Info:Current MaxSpatialBitrate is invalid

When the video bitrate is 10M (`-b:v 10M`), the report includes the following

> iTargetBitrate= 10000000;iMaxBitrate= 10000000;
> .iSpatialBitrate= 10000000; .iMaxSpatialBitrate= 10000000; 
> Info:Setting MaxSpatialBitrate (10000000) the same at SpatialBitrate (10000000) will make the actual bit rate lower than SpatialBitrate

Testing on the same file and only changing 10m to 10M in types.py confirms that the bitrate is always much higher with 10M.

This is one of the only parts of FF* that is case-sensitive, and I greatly dislike it. Plus, it is poorly documented: it is buried in the docs and all of the examples in the documentation use k/K, which is the _only_ suffix with the same meaning whether upper or lower case.

[aeinfo_test_ALTERED_10M.txt](https://github.com/WyattBlue/auto-editor/files/10927187/aeinfo_test_ALTERED_10M.txt)
[aeinfo_test_ALTERED_normal.txt](https://github.com/WyattBlue/auto-editor/files/10927188/aeinfo_test_ALTERED_normal.txt)
[auto-editor_debug_10M.txt](https://github.com/WyattBlue/auto-editor/files/10927189/auto-editor_debug_10M.txt)
[auto-editor_debug_normal.txt](https://github.com/WyattBlue/auto-editor/files/10927190/auto-editor_debug_normal.txt)
[ffmpeg_report_10M_truncated.log](https://github.com/WyattBlue/auto-editor/files/10927191/ffmpeg_report_10M_truncated.log)
[ffmpeg_report_normal_truncated.log](https://github.com/WyattBlue/auto-editor/files/10927192/ffmpeg_report_normal_truncated.log)
