### PR TITLE
Build Intel libvpl

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -3,6 +3,10 @@
 --passC:"-I./build/include"
 --passL:"-L./build/lib"
 
+@if gcc:
+  --passL:"-Wl,--as-needed"
+@end
+
 # Core FFmpeg libraries
 --passL:"-lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil"
 
@@ -21,6 +25,11 @@
 @if macosx:
   --passL:"-framework VideoToolbox -framework AudioToolbox"
   --passL:"-framework CoreFoundation -framework CoreMedia -framework CoreVideo"
+@else:
+  --passL:"-lvpl"
+  @if windows:
+    --passL:"-lbcrypt -lsetupapi -lole32 -luuid"
+  @end
 @end
 
 @if linux:
@@ -54,7 +63,7 @@
   @end
 @end
 
-@if enable_hevc or enable_whisper:
+@if enable_hevc or enable_whisper or linux:
   # C++ standard library
   @if macosx:
     --passL:"-lc++"


### PR DESCRIPTION
Adds support for Intel hardware-accelerated QSV encoders and decoders available for discrete (Arc) and integrated (Xe) Intel GPUs.