### PR TITLE
Use constant sort algo to improve `--preview` perf

### DIFF
--- a/ae.nimble
+++ b/ae.nimble
@@ -9,6 +9,7 @@ bin = @["main=auto-editor"]
 # Dependencies
 requires "nim >= 2.2.2"
 requires "tinyre#77469f5"
+requires "https://github.com/WyattBlue/csort"
 
 # Tasks
 import std/[os, strutils, strformat]

--- a/src/preview.nim
+++ b/src/preview.nim
@@ -1,5 +1,6 @@
-import std/[algorithm, sets, strutils, strformat]
+import std/[sets, strutils, strformat]
 from std/math import round
+import csort
 
 import av
 import ffmpeg


### PR DESCRIPTION
Measurable 15% performance boost (~200ms -> ~170ms) for 'Learning Vector Machines' video.