### PR TITLE
Rename 'makewasmweb' to 'makewasm'

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -234,5 +234,7 @@ jobs:
         run: brew install nim emscripten wabt
       - name: GCC/Clang version
         run: nim --version && gcc --version
-      - name: Build
-        run: nimble makeffwasm && nimble makewasmweb
+      - name: Build FFmpeg
+        run: nimble makeffwasm
+      - name: Compile
+        run: nimble makewasm

--- a/ae.nimble
+++ b/ae.nimble
@@ -934,7 +934,7 @@ Cflags: -I${{includedir}}
       --extra-ldflags="-L{wasmBuildPath}/lib -matomics -mbulk-memory -pthread" \""" & "\n" & setupCommonFlags(wasmPackages, crossWasm=true))
     makeInstall()
 
-task makewasmweb, "Compile to wasm for browser (requires emscripten, wabt)":
+task makewasm, "Compile to wasm32 (requires emscripten, wabt)":
   echo "Compiling for wasm (browser)..."
   if not dirExists("build_wasm"):
     echo "FFmpeg for wasm not found. Run 'nimble makeffwasm' first."


### PR DESCRIPTION
WASM implies the web. The former implies a standalone version would be called: 'makewasmstandalone', but we could just call it 'makewasi'.