### PR TITLE
Add platform agnostic `agSplitFile`, replace splitFile

### DIFF
--- a/src/cache.nim
+++ b/src/cache.nim
@@ -1,13 +1,13 @@
 import std/[algorithm, options, os, streams, strformat, strutils, times]
 
 import ./[about, ffmpeg, log]
-import ./util/rational
+import ./util/[fun, rational]
 
 import nimcrypto/sha
 
 proc procTag(path: string, tb: AVRational, kind, args: string): string =
   let modTime = getLastModificationTime(path).toUnix().int
-  let (_, name, ext) = splitFile(path)
+  let (_, name, ext) = agSplitFile(path)
   let key = &"{name}{ext}:{modTime:x}:{tb}:{args}"
   var ctx: sha1
   ctx.init()

--- a/src/cmds/cache.nim
+++ b/src/cmds/cache.nim
@@ -1,6 +1,7 @@
 import std/[os, strformat, terminal]
 
 import ../about
+import ../util/fun
 
 func formatBytes(intSize: BiggestInt): (string, string) =
   if intSize < 1024:
@@ -29,7 +30,7 @@ proc main*(args: seq[string]) =
         totalSize += size
         let (sizeNum, sizeUnit) = formatBytes(size)
 
-        let (_, key, _) = splitFile(path)
+        let (_, key, _) = agSplitFile(path)
         let hashPart = key[0 ..< 16]
         let restPart = key[16 .. ^1]
 

--- a/src/conductor.nim
+++ b/src/conductor.nim
@@ -102,15 +102,15 @@ proc setOutput(userOut, `export`, path: string): (string, string) =
   if userOut == "" or userOut == "-":
     if path == "":
       error "`--output` must be set." # When a timeline file is the input.
-    (dir, name, ext) = splitFile(path)
+    (dir, name, ext) = agSplitFile(path)
   else:
-    (dir, name, ext) = splitFile(userOut)
+    (dir, name, ext) = agSplitFile(userOut)
 
   let root = dir / name
 
   if ext == "":
     # Use `mp4` as the default, because it is most compatible.
-    ext = (if path == "": ".mp4" else: splitFile(path).ext)
+    ext = (if path == "": ".mp4" else: agSplitFile(path).ext)
 
   var myExport = `export` # Create mutable copy
   if myExport == "":
@@ -196,7 +196,7 @@ proc editMedia*(args: var mainArgs) =
     if args.inputs.len == 0:
       error "You need to give auto-editor an input file."
     let input = args.inputs[0]
-    let inputExt = splitFile(input).ext
+    let inputExt = agSplitFile(input).ext
 
     if inputExt in [".v1", ".v2", ".v3", ".json"]:
       tlV3 = readJson(readFile(input), interner)
@@ -312,7 +312,7 @@ proc editMedia*(args: var mainArgs) =
   if output == "-":
     error "Exporting media files to stdout is not supported."
 
-  let (_, _, outExt) = splitFile(output)
+  let (_, _, outExt) = agSplitFile(output)
   let rule = initRules(outExt.toLowerAscii)
   args.videoCodec = setVideoCodec(args.videoCodec, outExt, mi, rule)
   if args.audioCodec != "auto":
@@ -348,7 +348,7 @@ proc editMedia*(args: var mainArgs) =
       error "Timeline too complex to use clip-sequence export"
 
     func appendFilename(path, val: string): string =
-      let (dir, name, ext) = splitFile(path)
+      let (dir, name, ext) = agSplitFile(path)
       return (dir / name) & val & ext
 
     var clips2: seq[Clip2] = @[]

--- a/src/exports/fcp11.nim
+++ b/src/exports/fcp11.nim
@@ -3,7 +3,7 @@ import std/[strformat, strutils]
 from std/math import round
 
 import ../[action, ffmpeg, log, media, timeline]
-import ../util/rational
+import ../util/[fun, rational]
 
 #[
 Export a FCPXML 11 file readable with Final Cut Pro 10.6.8 or later.
@@ -118,7 +118,7 @@ proc fcp11WriteXml*(groupName, version, output: string, resolve: bool, tl: v3) =
     ptrToMi[ptrSrc] = mi
 
     if i == 0:
-      projName = splitFile(mi.path).name
+      projName = agSplitFile(mi.path).name
       srcDur = int(mi.duration * tl.tb)
       if resolve:
         tlDur = srcDur
@@ -136,7 +136,7 @@ proc fcp11WriteXml*(groupName, version, output: string, resolve: bool, tl: v3) =
     let audioChannels = (if mi.a.len == 0: "2" else: $mi.a[0].channels)
 
     let startPoint = parseSMPTE(mi.timecode, tl.tb)
-    let r2 = <>asset(id = id2, name = splitFile(mi.path).name,
+    let r2 = <>asset(id = id2, name = agSplitFile(mi.path).name,
         start = fraction(startPoint), hasVideo = hasVideo, format = id,
         hasAudio = hasAudio, audioSources = "1",
         audioChannels = audioChannels, duration = fraction(tlDur))

--- a/src/exports/fcp7.nim
+++ b/src/exports/fcp7.nim
@@ -4,7 +4,7 @@ when defined(windows):
   import std/strutils
 
 import ../[action, ffmpeg, media, timeline]
-import ../util/rational
+import ../util/[fun, rational]
 
 #[
 Premiere Pro uses the Final Cut Pro 7 XML Interchange Format
@@ -64,7 +64,7 @@ func speedup(speed: float): XmlNode =
 
 proc mediaDef(filedef: XmlNode, url: string, mi: MediaInfo, tl: v3, tb: int64,
     ntsc: string) =
-  filedef.add elem("name", mi.path.splitFile.name)
+  filedef.add elem("name", agSplitFile(mi.path).name)
   filedef.add elem("pathurl", url)
 
   let timecode = newElement("timecode")
@@ -126,7 +126,7 @@ proc resolveWriteAudio(audio: XmlNode, makeFiledef: proc(clipitem: XmlNode,
 
       let clipitem = newElement("clipitem")
       clipitem.attrs = {"id": &"clipitem-{clipItemNum}"}.toXmlAttributes
-      clipitem.add elem("name", mi.path.splitFile.name)
+      clipitem.add elem("name", agSplitFile(mi.path).name)
       clipitem.add elem("start", startVal)
       clipitem.add elem("end", endVal)
       clipitem.add elem("enabled", "TRUE")
@@ -199,7 +199,7 @@ proc premiereWriteAudio(audio: XmlNode, makeFiledef: proc(clipitem: XmlNode,
           "id": &"clipitem-{clipItemNum}",
           "premiereChannelType": "stereo"
         }.toXmlAttributes
-        clipitem.add elem("name", src.path.splitFile.name)
+        clipitem.add elem("name", agSplitFile(src.path).name)
         clipitem.add elem("enabled", "TRUE")
         clipitem.add elem("start", startVal)
         clipitem.add elem("end", endVal)
@@ -296,7 +296,7 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
 
       let thisClipid = &"clipitem-{j + 1}"
       let clipitem = <>clipitem(id = thisClipid)
-      clipitem.add elem("name", clip.src[].splitFile.name)
+      clipitem.add elem("name", agSplitFile(clip.src[]).name)
       clipitem.add elem("enabled", "TRUE")
       clipitem.add elem("start", startVal)
       clipitem.add elem("end", endVal)

--- a/src/exports/shotcut.nim
+++ b/src/exports/shotcut.nim
@@ -1,5 +1,4 @@
 import std/[strformat, xmltree]
-from std/os import splitFile
 from std/math import log10
 
 import ../[action, ffmpeg, timeline]
@@ -125,7 +124,7 @@ proc shotcutWriteMlt*(output: string, tl: v3) =
       producer.addProp("shotcut:producer", "avformat")
       if not lastSpeedWasVarispeed:
         producer.addProp("warp_pitch", "1")
-      producer.addProp("shotcut:caption", &"{splitFile(src).name} ({speedVal}x)")
+      producer.addProp("shotcut:caption", &"{agSplitFile(src).name} ({speedVal}x)")
 
       # Add volume filter if needed
       if volumeVal != 1.0:
@@ -144,7 +143,7 @@ proc shotcutWriteMlt*(output: string, tl: v3) =
       chain.addProp("eof", "pause")
       chain.addProp("resource", src)
       chain.addProp("mlt_service", "avformat")
-      chain.addProp("caption", splitFile(src).name)
+      chain.addProp("caption", agSplitFile(src).name)
 
       # Add volume filter if needed
       if volumeVal != 1.0:

--- a/src/main.nim
+++ b/src/main.nim
@@ -452,7 +452,7 @@ judge making cuts.
         error "URL inputs are not supported in the wasm build."
       else:
         args.inputs[i] = downloadVideo(myInput, args)
-    elif splitFile(myInput).ext == "":
+    elif agSplitFile(myInput).ext == "":
       if dirExists(myInput):
         error "Input must be a file or a URL, not a directory."
       if myInput.startsWith("-"):

--- a/src/render/format.nim
+++ b/src/render/format.nim
@@ -1,8 +1,8 @@
-import std/[heapqueue, os, options, sequtils, strformat, strutils, tables]
+import std/[heapqueue, options, sequtils, strformat, strutils, tables]
 from std/math import round
 
 import ../[av, ffmpeg, log, media, timeline]
-import ../util/[bar, rules, rational]
+import ../util/[bar, fun, rules, rational]
 import video
 import audio
 import subtitle
@@ -95,7 +95,7 @@ proc makeMedia*(args: mainArgs, tl: v3, outputPath: string, rules: Rules, bar: B
   var output = openWrite(outputPath)
   output.options = options
 
-  let (_, _, outExt) = splitFile(outputPath)
+  let (_, _, outExt) = agSplitFile(outputPath)
 
   var vEncCtx: ptr AVCodecContext = nil
   var vOutStream: ptr AVStream = nil

--- a/src/timeline.nim
+++ b/src/timeline.nim
@@ -2,7 +2,7 @@ import std/[options, os, sets, tables]
 from std/math import round
 
 import ./[action, av, ffmpeg, media, log, wavutil]
-import ./util/[color, lang, rational]
+import ./util/[color, fun, lang, rational]
 
 type v1* = object
   chunks*: seq[(int64, int64, float64)]
@@ -309,7 +309,7 @@ proc applyArgs*(tl: var v3, args: mainArgs) =
     tl.bg = args.background.get()
 
 func stem(path: string): string =
-  splitFile(path).name
+  agSplitFile(path).name
 
 func makeSaneTimebase*(tb: AVRational): AVRational =
   let tbFloat = round(tb.float64, 2)

--- a/src/util/fun.nim
+++ b/src/util/fun.nim
@@ -1,4 +1,4 @@
-import std/[base64, os, strutils, strformat]
+import std/[base64, strutils, strformat]
 from std/math import gcd, `mod`, round, trunc
 
 import ../log
@@ -107,8 +107,32 @@ func toTimecode*(secs: float, fmt: Code): string =
   of display:
     &"{sign}{h:d}:{m:02d}:{s.round.int:02d}"
 
+func agSplitFile*(path: string): tuple[dir, name, ext: string] =
+  ## Platform-independent splitFile. Treats both '/' and '\' as path separators
+  ## on every OS, so results don't drift between Linux, macOS, and Windows.
+  var namePos = 0
+  var dotPos = 0
+  for i in countdown(path.len - 1, 0):
+    if path[i] == '.' and dotPos == 0:
+      dotPos = i
+    elif path[i] == '/' or path[i] == '\\':
+      if namePos == 0:
+        namePos = i + 1
+      if dotPos > namePos:
+        result.name = substr(path, namePos, dotPos - 1)
+        result.ext = substr(path, dotPos)
+      else:
+        result.name = substr(path, namePos)
+      result.dir = substr(path, 0, max(0, namePos - 2))
+      return
+  if dotPos > 0:
+    result.name = substr(path, 0, dotPos - 1)
+    result.ext = substr(path, dotPos)
+  else:
+    result.name = path
+
 func splitext*(val: string): (string, string) =
-  let (dir, name, ext) = splitFile(val)
+  let (dir, name, ext) = agSplitFile(val)
   return (dir & "/" & name, ext)
 
 func aspectRatio*(width, height: int): tuple[w, h: int] =

--- a/tests/unit.nim
+++ b/tests/unit.nim
@@ -145,6 +145,19 @@ test "re":
 test "smpte":
   check parseSMPTE("13:44:05:21", AVRational(num: 24000, den: 1001)) == 1186701
 
+test "agSplitFile":
+  check agSplitFile("/").ext == ""
+  check agSplitFile("/.").ext == ""
+  check agSplitFile("/.foo").ext == ""
+  check agSplitFile("./foo").ext == ""
+  check agSplitFile("/foo").ext == ""
+  check agSplitFile("/foo.txt").ext == ".txt"
+  check agSplitFile("/foo.txt/bar").ext == ""
+  check agSplitFile("C:\\").ext == ""
+  check agSplitFile("C:\\.").ext == ""
+  check agSplitFile("C:\\foo.txt").ext == ".txt"
+  check agSplitFile("C:\\foo.txt\\bar").ext == ""
+
 test "uuid":
   # Test that genUuid generates valid RFC 4122 version 4 UUIDs
   for i in 1..3:


### PR DESCRIPTION
Nim's splitFile is platform-dependent, which can cause divergent behavior on otherwise pure operations like ShotCut's export. agSplitFile treats both '/' and '\' as separators on every OS, and skips a leading dot in the basename so hidden files like '/.foo' report no extension.