### PR TITLE
Fix `--export premiere` exporting mono sources as one-sided audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
  - Fix `--export resolve`/`final-cut-pro` offsetting every clip's timeline position by the media's start timecode, breaking the edit for footage with embedded timecode
  - Fix `--export resolve`/`final-cut-pro` writing an invalid sequence `audioLayout` (e.g. `mono`) rejected by Final Cut Pro; layouts now map to `stereo` or `surround`
  - Fix `--export final-cut-pro` setting each `asset`'s `duration` to the edited timeline length instead of the source media's duration
+ - Fix `--export premiere` forcing mono sources into an exploded stereo track-pair, leaving the audio playing on only one side; mono sources now export as a single `Mono` track
+ - Fix `--export premiere` writing duplicate `clipitem` ids and dangling `<link>` references

--- a/src/exports/fcp7.nim
+++ b/src/exports/fcp7.nim
@@ -158,8 +158,44 @@ proc resolveWriteAudio(audio: XmlNode, makeFiledef: proc(clipitem: XmlNode,
       track.add clipitem
     audio.add track
 
+type AudioTrackInfo = object
+  layerIdx: int         # Index into tl.a
+  isStereo: bool        # Stereo source -> exploded track-pair; else mono track
+  explodedIndex: int    # currentExplodedTrackIndex (0 or 1); 0 for mono
+  sourceTrackIndex: int # sourcetrack/trackindex into the source file
+  firstClipId: int      # clipitem id of this track's first clip
+
+proc planPremiereAudio(tl: v3, ptrToMi: Table[ptr string, MediaInfo],
+    firstAudioId: int): seq[AudioTrackInfo] =
+  ## Lay out the audio tracks. A stereo (or higher) source is split into two
+  ## exploded stereo tracks; a mono source becomes a single mono track. The
+  ## exploded structure can't represent mono: Premiere derives each channel
+  ## from currentExplodedTrackIndex, so a mono source's second exploded track
+  ## would read a non-existent channel and play silent on one side.
+  var nextId = firstAudioId
+  var channelOffset = 0
+  for layerIdx, alayer in tl.a:
+    var channels = 1
+    if alayer.len > 0:
+      let mi = ptrToMi[alayer[0].src]
+      let st = alayer[0].stream.int
+      if st >= 0 and st < mi.a.len:
+        channels = max(1, mi.a[st].channels.int)
+    let isStereo = channels >= 2
+    for explodedIndex in 0 ..< (if isStereo: 2 else: 1):
+      result.add AudioTrackInfo(
+        layerIdx: layerIdx,
+        isStereo: isStereo,
+        explodedIndex: explodedIndex,
+        sourceTrackIndex: channelOffset + explodedIndex + 1,
+        firstClipId: nextId,
+      )
+      nextId += alayer.len
+    channelOffset += channels
+
 proc premiereWriteAudio(audio: XmlNode, makeFiledef: proc(clipitem: XmlNode,
-    mi: MediaInfo), tl: v3, ptrToMi: Table[ptr string, MediaInfo]) =
+    mi: MediaInfo), tl: v3, ptrToMi: Table[ptr string, MediaInfo],
+    audioPlan: seq[AudioTrackInfo]) =
   audio.add elem("numOutputChannels", "2")
   let aformat = newElement("format")
   let aschar = newElement("samplecharacteristics")
@@ -169,62 +205,57 @@ proc premiereWriteAudio(audio: XmlNode, makeFiledef: proc(clipitem: XmlNode,
   audio.add aformat
 
   let hasVideo = tl.v.len > 0 and tl.v[0].len > 0
-  var t = 0
-  for alayer in tl.a:
-    for channelcount in 0..1: # Because "stereo" is hardcoded
-      t += 1
-      let track = newElement("track")
-      track.attrs = {
-        "currentExplodedTrackIndex": $channelcount,
-        "totalExplodedTrackCount": "2", # Because "stereo" is hardcoded
-        "premiereTrackType": "Stereo"
+  for atrack in audioPlan:
+    let alayer = tl.a[atrack.layerIdx]
+    let track = newElement("track")
+    track.attrs = {
+      "currentExplodedTrackIndex": $atrack.explodedIndex,
+      "totalExplodedTrackCount": (if atrack.isStereo: "2" else: "1"),
+      "premiereTrackType": (if atrack.isStereo: "Stereo" else: "Mono")
+    }.toXmlAttributes
+
+    if hasVideo and atrack.isStereo:
+      track.add elem("outputchannelindex", $(atrack.explodedIndex + 1))
+
+    for j, aclip in alayer.pairs:
+      let src = ptrToMi[aclip.src]
+
+      let startVal = $aclip.start
+      let endVal = $(aclip.start + aclip.dur)
+      let inVal = $aclip.offset
+      let outVal = $(aclip.offset + aclip.dur)
+
+      let clipitem = newElement("clipitem")
+      clipitem.attrs = {
+        "id": &"clipitem-{atrack.firstClipId + j}",
+        "premiereChannelType": (if atrack.isStereo: "stereo" else: "mono")
       }.toXmlAttributes
+      clipitem.add elem("name", agSplitFile(src.path).name)
+      clipitem.add elem("enabled", "TRUE")
+      clipitem.add elem("start", startVal)
+      clipitem.add elem("end", endVal)
+      clipitem.add elem("in", inVal)
+      clipitem.add elem("out", outVal)
 
-      if hasVideo:
-        track.add elem("outputchannelindex", $(channelcount + 1))
+      makeFiledef(clipitem, src)
 
-      for j, aclip in alayer.pairs:
-        let src = ptrToMi[aclip.src]
+      let sourcetrack = newElement("sourcetrack")
+      sourcetrack.add elem("mediatype", "audio")
+      sourcetrack.add elem("trackindex", $atrack.sourceTrackIndex)
+      clipitem.add sourcetrack
 
-        let startVal = $aclip.start
-        let endVal = $(aclip.start + aclip.dur)
-        let inVal = $aclip.offset
-        let outVal = $(aclip.offset + aclip.dur)
+      let labels = newElement("labels")
+      labels.add elem("label2", "Iris")
+      clipitem.add labels
 
-        let clipItemNum = if not hasVideo: j + 1 else: alayer.len + 1 + j + (
-            t * alayer.len)
+      let effectGroup = tl.effects[aclip.effects]
+      for effect in effectGroup:
+        if effect.kind in [actSpeed, actVarispeed]:
+          clipitem.add speedup(effect.val * 100)
+          break
 
-        let clipitem = newElement("clipitem")
-        clipitem.attrs = {
-          "id": &"clipitem-{clipItemNum}",
-          "premiereChannelType": "stereo"
-        }.toXmlAttributes
-        clipitem.add elem("name", agSplitFile(src.path).name)
-        clipitem.add elem("enabled", "TRUE")
-        clipitem.add elem("start", startVal)
-        clipitem.add elem("end", endVal)
-        clipitem.add elem("in", inVal)
-        clipitem.add elem("out", outVal)
-
-        makeFiledef(clipitem, src)
-
-        let sourcetrack = newElement("sourcetrack")
-        sourcetrack.add elem("mediatype", "audio")
-        sourcetrack.add elem("trackindex", $t)
-        clipitem.add sourcetrack
-
-        let labels = newElement("labels")
-        labels.add elem("label2", "Iris")
-        clipitem.add labels
-
-        let effectGroup = tl.effects[aclip.effects]
-        for effect in effectGroup:
-          if effect.kind in [actSpeed, actVarispeed]:
-            clipitem.add speedup(effect.val * 100)
-            break
-
-        track.add clipitem
-      audio.add track
+      track.add clipitem
+    audio.add track
 
 proc handlePath(src: string): string =
   let absPath = src.absolutePath()
@@ -259,6 +290,11 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
       fileDefs.incl(pathurl)
     clipitem.add filedef
 
+  let hasVideo = tl.v.len > 0 and tl.v[0].len > 0
+  let firstAudioId = (if hasVideo: tl.v[0].len + 1 else: 1)
+  let audioPlan = (if resolve: @[]
+                   else: planPremiereAudio(tl, ptrToMi, firstAudioId))
+
   let xmeml = <>xmeml(version = "5")
   let sequence = (if resolve: <>sequence() else: <>sequence(explodedTracks = "true"))
 
@@ -285,7 +321,7 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
   vformat.add vschar
   video.add vformat
 
-  if tl.v.len > 0 and tl.v[0].len > 0:
+  if hasVideo:
     let track = newElement("track")
 
     for j, clip in tl.v[0].pairs:
@@ -322,11 +358,18 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
         link2.add elem("linkclipref", &"clipitem-{tl.v[0].len + j + 1}")
         clipitem.add link2
       else:
-        for i in 0..<(1 + mi.a.len * 2): # `2` because stereo
+        let vlink = newElement("link")
+        vlink.add elem("linkclipref", thisClipid)
+        vlink.add elem("mediatype", "video")
+        vlink.add elem("trackindex", "1")
+        vlink.add elem("clipindex", $(j + 1))
+        clipitem.add vlink
+        for k, atrack in audioPlan:
+          if j >= tl.a[atrack.layerIdx].len: continue
           let link = newElement("link")
-          link.add elem("linkclipref", &"clipitem-{(i * tl.v[0].len) + j + 1}")
-          link.add elem("mediatype", if i == 0: "video" else: "audio")
-          link.add elem("trackindex", $max(i, 1))
+          link.add elem("linkclipref", &"clipitem-{atrack.firstClipId + j}")
+          link.add elem("mediatype", "audio")
+          link.add elem("trackindex", $(k + 1))
           link.add elem("clipindex", $(j + 1))
           clipitem.add link
 
@@ -340,7 +383,7 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
   if resolve:
     resolveWriteAudio(audio, makeFiledef, tl, ptrToMi)
   else:
-    premiereWriteAudio(audio, makeFiledef, tl, ptrToMi)
+    premiereWriteAudio(audio, makeFiledef, tl, ptrToMi, audioPlan)
 
   media.add audio
   sequence.add media

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,6 +4,7 @@ import hashlib
 import itertools
 import os
 import random
+import re
 import shutil
 import subprocess
 import sys
@@ -558,6 +559,37 @@ class Runner:
 
             p_xml = self.main([f"resources/{test_name}"], ["-exp"], "out.xml")
             self.main([p_xml], [])
+
+    def test_premiere_mono(self) -> None:
+        # A mono source must export as a single `Mono` track, not an exploded
+        # stereo pair whose 2nd track hits a non-existent channel. See #856.
+        p_xml = self.main(["resources/mono.mp3"], ["-exp"], "mono.xml")
+        with open(p_xml) as file:
+            content = file.read()
+
+        assert 'premiereTrackType="Mono"' in content
+        assert 'totalExplodedTrackCount="1"' in content
+        assert 'premiereChannelType="mono"' in content
+        assert "<trackindex>2</trackindex>" not in content
+
+        ids = re.findall(r'clipitem id="([^"]+)"', content)
+        assert ids and len(ids) == len(set(ids))
+        self.main([p_xml], [])
+
+    def test_premiere_stereo(self) -> None:
+        p_xml = self.main(["resources/testsrc.mkv"], ["-exp"], "stereo.xml")
+        with open(p_xml) as file:
+            content = file.read()
+
+        assert 'premiereTrackType="Stereo"' in content
+        assert 'currentExplodedTrackIndex="0"' in content
+        assert 'currentExplodedTrackIndex="1"' in content
+        assert "<trackindex>1</trackindex>" in content
+        assert "<trackindex>2</trackindex>" in content
+
+        ids = re.findall(r'clipitem id="([^"]+)"', content)
+        assert ids and len(ids) == len(set(ids))
+        self.main([p_xml], [])
 
     def test_export(self):
         for test_name in all_files:


### PR DESCRIPTION
Mono sources were forced into an exploded stereo track-pair. Premiere derives each channel from currentExplodedTrackIndex, so the second exploded track read a non-existent source channel and played silent on one side. Mono sources now export as a single `Mono` track with totalExplodedTrackCount="1".

Also fixes the audio section writing duplicate `clipitem` ids and dangling `<link>` references.

See discussion #856