### PR TITLE
Improve ASS dialogue parsing and subtitle handling

### DIFF
--- a/src/analyze/subtitle.nim
+++ b/src/analyze/subtitle.nim
@@ -1,4 +1,4 @@
-from std/math import round
+from std/math import floor, ceil
 
 import ../[av, ffmpeg]
 import ../util/rational
@@ -35,8 +35,11 @@ proc subtitle*(container: InputContainer, tb: AVRational, pattern: Re,
       let
         startFloat = float(packet.pts * subtitleStream.time_base)
         durFloat = float(packet.duration * subtitleStream.time_base)
-        start = round(startFloat * tb).int
-        `end` = round((startFloat + durFloat) * tb).int
+        # A subtitle is active for any frame it overlaps, so snap outward:
+        # floor the start, ceil the end. round() could clip a frame the
+        # subtitle actually touches.
+        start = floor(startFloat * tb).int
+        `end` = ceil((startFloat + durFloat) * tb).int
 
       var gotSubtitle: cint = 0
       let ret = avcodec_decode_subtitle2(codecCtx, addr subtitle,

--- a/src/av.nim
+++ b/src/av.nim
@@ -508,13 +508,18 @@ func dialogue*(assText: string): string =
     curChar = assText[i]
     nextChar = (if i + 1 >= textLen: '\0' else: assText[i + 1])
 
-    if curChar == '\\' and nextChar == 'N':
-      result &= "\n"
-      i += 2
-      continue
-
     if not state:
-      if curChar == '{' and nextChar != '\\':
+      if curChar == '\\' and nextChar == 'N':
+        # `\N` is a hard line break.
+        result &= "\n"
+        i += 2
+        continue
+      if curChar == '\\' and nextChar in {'n', 'h'}:
+        # `\n` (soft break) and `\h` (non-breaking space) collapse to a space.
+        result &= " "
+        i += 2
+        continue
+      if curChar == '{' and assText.find('}', int(i) + 1) != -1:
         state = true
       else:
         result &= curChar

--- a/src/cmds/subdump.nim
+++ b/src/cmds/subdump.nim
@@ -1,10 +1,25 @@
+import std/[json, strutils]
+
 import ../[av, ffmpeg, log]
 
 proc main*(args: seq[string]) =
   av_log_set_level(AV_LOG_QUIET)
 
+  var
+    asJson = false
+    inputFiles: seq[string] = @[]
+  for key in args:
+    if key == "--json":
+      asJson = true
+    elif key.startsWith("--"):
+      error "Unknown option: " & key
+    else:
+      inputFiles.add key
+
+  var jsonOut = %* {}
+
   var container: InputContainer
-  for inputFile in args:
+  for inputFile in inputFiles:
     try:
       container = av.open(inputFile)
     except IOError as e:
@@ -16,25 +31,61 @@ proc main*(args: seq[string]) =
     for s in container.subtitle:
       subStreams.add s.index
 
+    var streamsJson: seq[JsonNode] = @[]
+
     for i, s in subStreams.pairs:
       let codecName = $avcodec_get_name(formatCtx.streams[s].codecpar.codec_id)
-      echo "file: " & inputFile & " (" & $i & ":" & codecName & ")"
+      if not asJson:
+        echo "file: " & inputFile & " (" & $i & ":" & codecName & ")"
 
+      let tbSeconds = formatCtx.streams[s].time_base.toDouble
+      var cues: seq[JsonNode] = @[]
       var codecCtx = initDecoder(formatCtx.streams[s].codecpar)
       var subtitle: AVSubtitle
       while av_read_frame(formatCtx, container.packet) >= 0:
         defer: av_packet_unref(container.packet)
 
         if container.packet.stream_index == s.cint:
+          let pkt = container.packet
           var gotSubtitle: cint = 0
           let ret = avcodec_decode_subtitle2(codecCtx, addr subtitle,
-            addr gotSubtitle, container.packet)
+            addr gotSubtitle, pkt)
 
           if ret >= 0 and gotSubtitle != 0:
             defer: avsubtitle_free(addr subtitle)
+            # AVSubtitle.pts is in AV_TIME_BASE when set; otherwise fall back to
+            # the packet pts in the stream time_base. Display times are ms
+            # relative to that base; some codecs (e.g. mov_text) instead carry
+            # the duration on the packet.
+            let base =
+              if subtitle.pts != AV_NOPTS_VALUE: subtitle.pts.float / AV_TIME_BASE.float
+              elif pkt.pts != AV_NOPTS_VALUE: pkt.pts.float * tbSeconds
+              else: 0.0
+            let start = base + subtitle.start_display_time.float / 1000.0
+            let finish =
+              if subtitle.end_display_time > subtitle.start_display_time:
+                base + subtitle.end_display_time.float / 1000.0
+              elif pkt.duration > 0:
+                base + pkt.duration.float * tbSeconds
+              else:
+                start
             for i in 0..<subtitle.num_rects:
               let rect = subtitle.rects[i]
               if rect.`type` == SUBTITLE_ASS and rect.ass != nil:
-                echo $rect.ass
+                if asJson:
+                  let text = dialogue($rect.ass).strip()
+                  if text.len > 0:
+                    cues.add( %* {"start": start, "end": finish, "text": text})
+                else:
+                  echo $rect.ass
 
-    echo "------"
+      if asJson:
+        streamsJson.add( %* {"stream": i, "codec": codecName, "cues": cues})
+
+    if asJson:
+      jsonOut[inputFile] = %* streamsJson
+    else:
+      echo "------"
+
+  if asJson:
+    echo $jsonOut

--- a/tests/unit.nim
+++ b/tests/unit.nim
@@ -43,6 +43,21 @@ test "dialogue":
   check "0,0,Default,,0,0,0,,oop".dialogue == "oop"
   check "0,0,Default,,0,0,0,,boop".dialogue == "boop"
 
+  # Override blocks are stripped.
+  check "0,0,Default,,0,0,0,,{\\b1}bold{\\b0}".dialogue == "bold"
+  check "0,0,Default,,0,0,0,,{\\an8}top".dialogue == "top"
+
+  # Text escapes: \N -> newline, \n and \h -> space.
+  check "0,0,Default,,0,0,0,,a\\Nb".dialogue == "a\nb"
+  check "0,0,Default,,0,0,0,,a\\nb".dialogue == "a b"
+  check "0,0,Default,,0,0,0,,a\\hb".dialogue == "a b"
+
+  # A stray '{' with no closing '}' is literal text.
+  check "0,0,Default,,0,0,0,,cost is {5".dialogue == "cost is {5"
+
+  # Escapes inside an override block are not interpreted.
+  check "0,0,Default,,0,0,0,,{\\fnArial}hi".dialogue == "hi"
+
 test "encoder":
   let (_, encoderCtx) = initEncoder("pcm_s16le")
   check encoderCtx.codec_type == AVMEDIA_TYPE_AUDIO


### PR DESCRIPTION
Also add `--json` to subdump cmd. Harden dialogue (see tests). Snap subtitle spans outward (floor start / ceil end) so a frame the subtitle touches isn't clipped.