### PR TITLE
Skip demuxing unused streams during audio analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,8 @@
 ## Features
  - Add AMD AMF hardware encoders (`h264_amf`, `hevc_amf`, `av1_amf`) for x86_64 Windows and Linux builds.
 
+## Performance
+ - Skip demuxing unused streams during audio analysis and rendering, which is significantly faster when working with high-bitrate video files.
+
 ## Fixes
  -

--- a/src/av.nim
+++ b/src/av.nim
@@ -131,10 +131,28 @@ proc mediaLength*(container: InputContainer): AVRational =
 
   error "No audio or video stream found"
 
+proc setActiveStream*(container: InputContainer, index: cint) =
+  ## Tell the demuxer to discard packets for every stream except `index`, so
+  ## av_read_frame skips demuxing streams we don't decode (e.g. video while
+  ## analyzing audio). Call resetDiscards() when finished to restore the
+  ## container for callers that read every stream.
+  for i in 0 ..< container.formatContext.nb_streams.int:
+    let s = container.formatContext.streams[i]
+    s.discardLevel = (if s.index == index: AVDISCARD_DEFAULT else: AVDISCARD_ALL)
+
+proc resetDiscards*(container: InputContainer) =
+  for i in 0 ..< container.formatContext.nb_streams.int:
+    container.formatContext.streams[i].discardLevel = AVDISCARD_DEFAULT
+
 iterator decode*(container: InputContainer, index: cint, codecCtx: ptr AVCodecContext,
     frame: ptr AVFrame): ptr AVFrame =
   var ret: cint
   var packet = container.packet
+  # We decode a single stream to EOF here, so let the demuxer skip every other
+  # stream instead of reading packets we'd only throw away (big win when
+  # analyzing audio in a high-bitrate video file).
+  container.setActiveStream(index)
+  defer: container.resetDiscards()
   while av_read_frame(container.formatContext, packet) >= 0:
     defer: av_packet_unref(packet)
 

--- a/src/ffmpeg.nim
+++ b/src/ffmpeg.nim
@@ -54,6 +54,7 @@ proc av_get_known_color_name*(color_idx: cint, rgbp: ptr ptr uint8): cstring
 
 type
   AVMediaType* = cint
+  AVDiscard* = cint
   AVCodecID* = cint
   AVColorRange* = cint
   AVColorPrimaries* = cint
@@ -145,6 +146,7 @@ type
     avg_frame_rate*: AVRational
     attached_pic*: AVPacket
     disposition*: cint
+    discardLevel* {.importc: "discard".}: AVDiscard
 
   AVCodec* {.importc, incompleteStruct, header: "<libavcodec/codec.h>".} = object
     name*: cstring
@@ -251,6 +253,8 @@ const
   AVMEDIA_TYPE_DATA* = AVMediaType(2)
   AVMEDIA_TYPE_SUBTITLE* = AVMediaType(3)
   AVMEDIA_TYPE_ATTACHMENT* = AVMediaType(4)
+  AVDISCARD_DEFAULT* = AVDiscard(0)  # Discard useless packets like 0-size packets in AVI
+  AVDISCARD_ALL* = AVDiscard(48)     # Discard all packets for the stream
   AVFMT_GLOBALHEADER* = 0x0040
   AV_CODEC_FLAG_GLOBAL_HEADER* = 4194304 # 1 << 22
   AV_TIME_BASE* = 1000000

--- a/src/render/audio.nim
+++ b/src/render/audio.nim
@@ -137,6 +137,7 @@ proc newGetter(path: string, stream: int32, rate: cint): Getter =
   result = new(Getter)
   result.container = av.open(path)
   result.stream = result.container.audio[stream]
+  result.container.setActiveStream(result.stream.index)
   result.rate = rate
   result.decoderCtx = initDecoder(result.stream.codecpar)
   new(result.layout)


### PR DESCRIPTION
Set `AVStream.discard` to AVDISCARD_ALL on every stream except the one being decoded in the decode iterator, so the demuxer skips packets we'd only throwaway. ~9x faster audio analysis on high-bitrate video files; no change for low-bitrate files.