### PR TITLE
Add indeterminate progress bar for unknown durations

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -31,6 +31,7 @@ else:
     --clang.linkerexe:emcc
 
     switch("passC", "-pthread")
+    switch("passC", "-msimd128")
     switch("passC", "-g0")
     switch("passL", "-pthread")
     switch("passL", "-g0")

--- a/src/analyze/audio.nim
+++ b/src/analyze/audio.nim
@@ -95,7 +95,7 @@ proc hasChunk(iter: AudioIterator): bool =
   let needed = ceil(iter.exactSize).int
   return availableSamples >= needed
 
-proc readChunk(iter: AudioIterator): float32 =
+proc readChunk(iter: AudioIterator): Unorm16 =
   # Calculate chunk size with accumulated error
   let sizeWithError = iter.exactSize + iter.accumulatedError
   let currentSize = round(sizeWithError).int
@@ -107,25 +107,25 @@ proc readChunk(iter: AudioIterator): float32 =
   )
   let totalSamples = samplesRead * iter.channelCount
 
+  var maxAbs: int32 = 0
   when defined(arm64) or defined(aarch64):
     var vmax = neonDup16(0'i16)
     var i = 0
     while i + 8 <= totalSamples:
       vmax = neonMax16(vmax, neonQAbs16(neonLoad16(addr samples[i])))
       i += 8
-    var maxAbs = int32(neonMaxAcross16(vmax))
+    maxAbs = int32(neonMaxAcross16(vmax))
     while i < totalSamples:
       let v = abs(int32(samples[i]))
       if v > maxAbs: maxAbs = v
       i += 1
-    return float32(maxAbs) / 32767.0'f32
   else:
-    var maxAbs: int32 = 0
     for i in 0 ..< totalSamples:
       let v = abs(int32(samples[i]))
       if v > maxAbs:
         maxAbs = v
-    return float32(maxAbs) / 32767.0'f32
+
+  return toUnorm16(float32(maxAbs) / 32767.0'f32)
 
 proc readPeaks(iter: AudioIterator): tuple[lo, hi: float32] =
   let sizeWithError = iter.exactSize + iter.accumulatedError
@@ -197,7 +197,7 @@ iterator peaks*(processor: var AudioProcessor, container: InputContainer,
       yield (firstSamplePos + bucketIdx * spb, lo, hi)
       bucketIdx += 1
 
-iterator loudness*(processor: var AudioProcessor, container: InputContainer): float32 =
+iterator loudness*(processor: var AudioProcessor, container: InputContainer): Unorm16 =
   var frame = av_frame_alloc()
   if frame == nil:
     error "Could not allocate frame"
@@ -259,7 +259,7 @@ proc audio*(bar: Bar, container: InputContainer, path: string, tb: AVRational,
   result = newSeqOfCap[Unorm16](int(inaccurateDur) + 1)
   var i: float = 0
   for value in processor.loudness(container):
-    result.add toUnorm16(value)
+    result.add value
     bar.tick(i)
     i += 1
 

--- a/src/analyze/audio.nim
+++ b/src/analyze/audio.nim
@@ -244,12 +244,18 @@ proc audio*(bar: Bar, container: InputContainer, path: string, tb: AVRational,
   )
 
   var inaccurateDur: float = 1024.0
+  var knownDur = true
   if audioStream.duration != AV_NOPTS_VALUE and audioStream.time_base != AV_NOPTS_VALUE:
     inaccurateDur = float(audioStream.duration) * float(audioStream.time_base * tb)
   elif container.duration != 0.0:
     inaccurateDur = container.duration / float(tb)
+  else:
+    knownDur = false
 
-  bar.start(inaccurateDur, "Analyzing audio volume")
+  if knownDur:
+    bar.start(inaccurateDur, "Analyzing audio volume")
+  else:
+    bar.startIndeterminate("Analyzing audio volume")
   result = newSeqOfCap[Unorm16](int(inaccurateDur) + 1)
   var i: float = 0
   for value in processor.loudness(container):

--- a/src/analyze/audio.nim
+++ b/src/analyze/audio.nim
@@ -14,6 +14,18 @@ when defined(arm64) or defined(aarch64):
   proc neonMax16(a, b: Vec16x8): Vec16x8 {.importc: "vmaxq_s16", header: "<arm_neon.h>".}
   proc neonMaxAcross16(v: Vec16x8): int16 {.importc: "vmaxvq_s16", header: "<arm_neon.h>".}
 
+elif defined(amd64) or defined(i386):
+  type
+    M128i {.importc: "__m128i", header: "<emmintrin.h>".} = object
+
+  proc sseZero(): M128i {.importc: "_mm_setzero_si128", header: "<emmintrin.h>".}
+  proc sseLoad(p: pointer): M128i {.importc: "_mm_loadu_si128", header: "<emmintrin.h>".}
+  proc sseStore(p: pointer, v: M128i) {.importc: "_mm_storeu_si128", header: "<emmintrin.h>".}
+  proc sseSubs16(a, b: M128i): M128i {.importc: "_mm_subs_epi16", header: "<emmintrin.h>".}
+  proc sseMax16(a, b: M128i): M128i {.importc: "_mm_max_epi16", header: "<emmintrin.h>".}
+  # Saturating abs: max(v, 0 - v) clamps -32768 -> 32767 (subs saturates).
+  proc sseAbs16(v: M128i): M128i {.inline.} = sseMax16(v, sseSubs16(sseZero(), v))
+
 type
   AudioIterator = ref object
     resampler: AudioResampler
@@ -109,12 +121,43 @@ proc readChunk(iter: AudioIterator): Unorm16 =
 
   var maxAbs: int32 = 0
   when defined(arm64) or defined(aarch64):
-    var vmax = neonDup16(0'i16)
+    # Four independent accumulators hide the latency of the abs/max chain.
+    var v0 = neonDup16(0'i16)
+    var v1 = neonDup16(0'i16)
+    var v2 = neonDup16(0'i16)
+    var v3 = neonDup16(0'i16)
     var i = 0
+    while i + 32 <= totalSamples:
+      v0 = neonMax16(v0, neonQAbs16(neonLoad16(addr samples[i])))
+      v1 = neonMax16(v1, neonQAbs16(neonLoad16(addr samples[i + 8])))
+      v2 = neonMax16(v2, neonQAbs16(neonLoad16(addr samples[i + 16])))
+      v3 = neonMax16(v3, neonQAbs16(neonLoad16(addr samples[i + 24])))
+      i += 32
+    var vmax = neonMax16(neonMax16(v0, v1), neonMax16(v2, v3))
     while i + 8 <= totalSamples:
       vmax = neonMax16(vmax, neonQAbs16(neonLoad16(addr samples[i])))
       i += 8
     maxAbs = int32(neonMaxAcross16(vmax))
+    while i < totalSamples:
+      let v = abs(int32(samples[i]))
+      if v > maxAbs: maxAbs = v
+      i += 1
+  elif defined(amd64) or defined(i386):
+    var v0 = sseZero()
+    var v1 = sseZero()
+    var i = 0
+    while i + 16 <= totalSamples:
+      v0 = sseMax16(v0, sseAbs16(sseLoad(addr samples[i])))
+      v1 = sseMax16(v1, sseAbs16(sseLoad(addr samples[i + 8])))
+      i += 16
+    var vmax = sseMax16(v0, v1)
+    while i + 8 <= totalSamples:
+      vmax = sseMax16(vmax, sseAbs16(sseLoad(addr samples[i])))
+      i += 8
+    var lanes: array[8, int16]
+    sseStore(addr lanes[0], vmax)
+    for lane in lanes:
+      if int32(lane) > maxAbs: maxAbs = int32(lane)
     while i < totalSamples:
       let v = abs(int32(samples[i]))
       if v > maxAbs: maxAbs = v
@@ -124,6 +167,7 @@ proc readChunk(iter: AudioIterator): Unorm16 =
       let v = abs(int32(samples[i]))
       if v > maxAbs:
         maxAbs = v
+        if maxAbs >= 32767: break
 
   return toUnorm16(float32(maxAbs) / 32767.0'f32)
 

--- a/src/analyze/audio.nim
+++ b/src/analyze/audio.nim
@@ -14,6 +14,19 @@ when defined(arm64) or defined(aarch64):
   proc neonMax16(a, b: Vec16x8): Vec16x8 {.importc: "vmaxq_s16", header: "<arm_neon.h>".}
   proc neonMaxAcross16(v: Vec16x8): int16 {.importc: "vmaxvq_s16", header: "<arm_neon.h>".}
 
+elif defined(emscripten):
+  type
+    V128 {.importc: "v128_t", header: "<wasm_simd128.h>".} = object
+
+  proc wasmSplat16(x: int16): V128 {.importc: "wasm_i16x8_splat", header: "<wasm_simd128.h>".}
+  proc wasmLoad(p: pointer): V128 {.importc: "wasm_v128_load", header: "<wasm_simd128.h>".}
+  proc wasmStore(p: pointer, v: V128) {.importc: "wasm_v128_store", header: "<wasm_simd128.h>".}
+  proc wasmSubSat16(a, b: V128): V128 {.importc: "wasm_i16x8_sub_sat", header: "<wasm_simd128.h>".}
+  proc wasmMax16(a, b: V128): V128 {.importc: "wasm_i16x8_max", header: "<wasm_simd128.h>".}
+  # Saturating abs: max(v, 0 - v). wasm_i16x8_abs would wrap -32768, so use
+  # sub_sat instead, which clamps -32768 -> 32767.
+  proc wasmAbs16(v: V128): V128 {.inline.} = wasmMax16(v, wasmSubSat16(wasmSplat16(0), v))
+
 elif defined(amd64) or defined(i386):
   type
     M128i {.importc: "__m128i", header: "<emmintrin.h>".} = object
@@ -138,6 +151,26 @@ proc readChunk(iter: AudioIterator): Unorm16 =
       vmax = neonMax16(vmax, neonQAbs16(neonLoad16(addr samples[i])))
       i += 8
     maxAbs = int32(neonMaxAcross16(vmax))
+    while i < totalSamples:
+      let v = abs(int32(samples[i]))
+      if v > maxAbs: maxAbs = v
+      i += 1
+  elif defined(emscripten):
+    var v0 = wasmSplat16(0)
+    var v1 = wasmSplat16(0)
+    var i = 0
+    while i + 16 <= totalSamples:
+      v0 = wasmMax16(v0, wasmAbs16(wasmLoad(addr samples[i])))
+      v1 = wasmMax16(v1, wasmAbs16(wasmLoad(addr samples[i + 8])))
+      i += 16
+    var vmax = wasmMax16(v0, v1)
+    while i + 8 <= totalSamples:
+      vmax = wasmMax16(vmax, wasmAbs16(wasmLoad(addr samples[i])))
+      i += 8
+    var lanes: array[8, int16]
+    wasmStore(addr lanes[0], vmax)
+    for lane in lanes:
+      if int32(lane) > maxAbs: maxAbs = int32(lane)
     while i < totalSamples:
       let v = abs(int32(samples[i]))
       if v > maxAbs: maxAbs = v

--- a/src/analyze/motion.nim
+++ b/src/analyze/motion.nim
@@ -139,7 +139,7 @@ iterator videoPipeline*(processor: VideoProcessor, filter: string): ptr AVFrame 
         yield filteredFrame
         av_frame_unref(filteredFrame)
 
-iterator motionness*(processor: var VideoProcessor, width, blur: int32): float32 =
+iterator motionness*(processor: var VideoProcessor, width, blur: int32): Unorm16 =
   var totalPixels: int = 0
   var firstTime: bool = true
   var prevIndex: int64 = -1
@@ -165,7 +165,7 @@ iterator motionness*(processor: var VideoProcessor, width, blur: int32): float32
 
     copyMem(currentFrame, filteredFrame.data[0], totalPixels)
 
-    var value: float32 = 0.0
+    var value: Unorm16 = toUnorm16(0.0'f32)
     if not firstTime:
       # Calculate motion by comparing with previous frame
       var diffCount: int32 = 0
@@ -173,9 +173,8 @@ iterator motionness*(processor: var VideoProcessor, width, blur: int32): float32
         if prevFrame[i] != currentFrame[i]:
           inc diffCount
 
-      value = float32(diffCount) / float32(totalPixels)
+      value = toUnorm16(float32(diffCount) / float32(totalPixels))
     else:
-      value = 0.0
       firstTime = false
 
     # Yield value for each frame index between previous and current
@@ -220,7 +219,7 @@ proc motion*(bar: Bar, container: InputContainer, path: string, tb: AVRational,
     bar.startIndeterminate("Analyzing motion")
   var i: float = 0
   for value in processor.motionness(width, blur):
-    result.add toUnorm16(value)
+    result.add value
     bar.tick(i)
     i += 1
 

--- a/src/analyze/motion.nim
+++ b/src/analyze/motion.nim
@@ -206,12 +206,18 @@ proc motion*(bar: Bar, container: InputContainer, path: string, tb: AVRational,
   )
 
   var inaccurateDur: float = 1024.0
+  var knownDur = true
   if videoStream.duration != AV_NOPTS_VALUE and videoStream.time_base != AV_NOPTS_VALUE:
     inaccurateDur = float(videoStream.duration) * float(videoStream.time_base * tb)
   elif container.duration != 0.0:
     inaccurateDur = container.duration / float(tb)
+  else:
+    knownDur = false
 
-  bar.start(inaccurateDur, "Analyzing motion")
+  if knownDur:
+    bar.start(inaccurateDur, "Analyzing motion")
+  else:
+    bar.startIndeterminate("Analyzing motion")
   var i: float = 0
   for value in processor.motionness(width, blur):
     result.add toUnorm16(value)

--- a/src/cmds/levels.nim
+++ b/src/cmds/levels.nim
@@ -167,8 +167,7 @@ proc main*(strArgs: seq[string]) =
       chunkDuration: chunkDuration
     )
 
-    for loudnessValue in processor.loudness(container):
-      let u = toUnorm16(loudnessValue)
+    for u in processor.loudness(container):
       emit u
       data.add u
     echo ""
@@ -187,8 +186,7 @@ proc main*(strArgs: seq[string]) =
       videoIndex: videoStream.index,
     )
 
-    for value in processor.motionness(width, blur):
-      let u = toUnorm16(value)
+    for u in processor.motionness(width, blur):
       emit u
       data.add u
     echo ""

--- a/src/render/audio.nim
+++ b/src/render/audio.nim
@@ -587,8 +587,6 @@ proc makeAudioFrames(fmt: AVSampleFormat, tl: v3, frameSize: int, layerIndices: 
   if tb.num == 0:
     error "Timeline timebase has zero numerator"
 
-  conwrite "Creating audio"
-
   # Collect all unique audio sources from specified layers.
   # Audio's getter calls av_seek_frame / av_read_frame on its container, so it
   # must have an AVFormatContext that's independent of the video decoder's —
@@ -926,11 +924,12 @@ proc makeAudioFrames(fmt: AVSampleFormat, tl: v3, frameSize: int, layerIndices: 
 
 proc makeMixedAudioFrames*(fmt: AVSampleFormat, tl: v3, frameSize: int, norm: Norm,
     cache: MediaCache = nil): iterator(): (ptr AVFrame, int64) =
-  # Create sequence of all layer indices efficiently
+
   let allLayerIndices = toSeq(0..<tl.a.len)
   return makeAudioFrames(fmt, tl, frameSize, allLayerIndices, mixLayers = true, norm, cache)
 
 proc makeNewAudioFrames*(fmt: AVSampleFormat, index: int32, tl: v3,
     frameSize: int, norm: Norm, cache: MediaCache = nil): iterator(): (ptr AVFrame, int64) =
+
   return makeAudioFrames(fmt, tl, frameSize, @[index.int], mixLayers = false, norm, cache)
 

--- a/src/render/format.nim
+++ b/src/render/format.nim
@@ -160,8 +160,11 @@ proc makeMedia*(args: mainArgs, tl: v3, outputPath: string, rules: Rules, bar: B
       audioStreams.add(aOutStream)
       audioEncoders.add(aEncCtx)
 
+      bar.startIndeterminate("Creating audio")
+
       let frameSize = if aEncCtx.frame_size > 0: aEncCtx.frame_size else: 1024
-      let audioFrameIter = makeMixedAudioFrames(encoder.sample_fmts[0], tl, frameSize, args.audioNormalize, cache)
+      let audioFrameIter = makeMixedAudioFrames(encoder.sample_fmts[0], tl, frameSize,
+          args.audioNormalize, cache)
       audioFrameIters.add(audioFrameIter)
   elif includeAudio:
     # Create separate streams for each timeline layer
@@ -192,9 +195,11 @@ proc makeMedia*(args: mainArgs, tl: v3, outputPath: string, rules: Rules, bar: B
         audioStreams.add(aOutStream)
         audioEncoders.add(aEncCtx)
 
+        bar.startIndeterminate("Creating audio")
+
         let frameSize = if aEncCtx.frame_size > 0: aEncCtx.frame_size else: 1024
-        let audioFrameIter = makeNewAudioFrames(encoder.sample_fmts[0], i.int32, tl, frameSize,
-            args.audioNormalize, cache)
+        let audioFrameIter = makeNewAudioFrames(encoder.sample_fmts[0], i.int32, tl,
+            frameSize, args.audioNormalize, cache)
         audioFrameIters.add(audioFrameIter)
 
   defer:

--- a/src/util/bar.nim
+++ b/src/util/bar.nim
@@ -46,8 +46,9 @@ type
     progress: Atomic[float]
     total: Atomic[float]
     shouldStop: Atomic[bool]
-    paused: Atomic[bool]   # set by end() to halt writes
-    sleeping: Atomic[bool] # set by worker to acknowledge it isn't writing
+    paused: Atomic[bool]        # set by end() to halt writes
+    sleeping: Atomic[bool]      # set by worker to acknowledge it isn't writing
+    indeterminate: Atomic[bool] # animate without a known total
     title: string
     lenTitle: int
     begin: float
@@ -82,19 +83,75 @@ proc formatProgressOutput(config: BarConfig, title: string, lenTitle, columns: i
     return &"{title}~{indexClamped}~{total}~{secsTilEta}"
   else:
     let newTime = prettyTime(begin + rate, config.ampm)
-    let percent = round(progress * 100, 1)
-    let pPad = " ".repeat(max(0, 4 - ($percent).len))
+
+    let percent = (if progress == 1.0: "100" else: $round(progress * 100, 1))
+    let pPad = " ".repeat(max(0, 4 - percent.len))
 
     let barLen = max(1, columns - lenTitle - 35)
     let barString = createBarString(config, progress, barLen)
 
     return &"  {config.icon}{title} {barString} {pPad}{percent}%  ETA {newTime}    "
 
+# Indeterminate sweep: one band whose leading and trailing edges each follow
+# their own eased timing, so it stretches as it accelerates in and squashes as
+# it slides out — Material Design style, but a single band (no overlap). The
+# band travels from off the left edge to off the right edge each `sweepCycle`
+# seconds, with a brief gap before re-entering.
+const sweepCycle = 1.8
+
+proc cubicBezier(x1, y1, x2, y2, t: float): float =
+  ## Evaluate a CSS cubic-bezier(x1,y1,x2,y2) easing at input fraction t.
+  proc sampleX(s: float): float =
+    let u = 1.0 - s
+    3 * u * u * s * x1 + 3 * u * s * s * x2 + s * s * s
+  proc sampleY(s: float): float =
+    let u = 1.0 - s
+    3 * u * u * s * y1 + 3 * u * s * s * y2 + s * s * s
+
+  # Invert x(s) = t with Newton-Raphson, then read off y(s).
+  var s = t
+  for _ in 0 ..< 8:
+    let x = sampleX(s) - t
+    let d = 3 * (1 - s) * (1 - s) * x1 + 6 * (1 - s) * s * (x2 - x1) +
+            3 * s * s * (1 - x2)
+    if abs(d) < 1e-6:
+      break
+    s = clamp(s - x / d, 0.0, 1.0)
+  sampleY(s)
+
+proc createIndeterminateBarString(config: BarConfig, phase: float, width: int): string =
+  ## A single eased band sweeping across the track.
+  # Edges run from -0.15 (off left) to 1.15 (off right). The leading edge
+  # accelerates early; the trailing edge lags then catches up.
+  let leading = -0.15 + 1.30 * cubicBezier(0.20, 0.80, 0.40, 1.00, phase)
+  let trailing = -0.15 + 1.30 * cubicBezier(0.60, 0.00, 0.75, 0.45, phase)
+
+  var cells = newSeq[string](width)
+  for i in 0 ..< width:
+    let center = (i.float + 0.5) / width.float
+    cells[i] = if center >= trailing and center <= leading: config.chars[^1]
+               else: config.chars[0]
+
+  result = config.brackets.left & cells.join("") & config.brackets.right
+
+proc formatIndeterminateOutput(config: BarConfig, title: string, lenTitle,
+    columns: int, elapsed: float): string =
+  if config.machine:
+    return &"{title}~-1~-1~{round(elapsed, 2)}"
+  else:
+    # No percent/ETA suffix, so the bar can stretch across most of the line.
+    let barLen = max(1, columns - lenTitle - 14)
+    let phase = (elapsed mod sweepCycle) / sweepCycle
+    let barString = createIndeterminateBarString(config, phase, barLen)
+    return &"  {config.icon}{title} {barString}  "
+
 proc progressWorker(data: ThreadData) {.thread.} =
   ## Background thread worker that handles progress bar updates with full format
   var lastProgress: float = -1
+  var lastFrame = -1
   let config = data.config[] # Dereference once and cache
   const sleepRate = 8 # ~120 FPS update rate
+  const animFps = 60.0 # indeterminate animation refresh rate
   var columns = terminalWidth()
   when defined(windows):
     var widthCounter = 0
@@ -117,6 +174,25 @@ proc progressWorker(data: ThreadData) {.thread.} =
       if widthCounter >= widthRefreshRate:
         columns = terminalWidth()
         widthCounter = 0
+
+    if data.indeterminate.load():
+      let elapsed = epochTime() - data.begin
+      let frame = int(elapsed * animFps)
+      if frame == lastFrame:
+        data.sleeping.store(true)
+        sleep(sleepRate)
+        continue
+      lastFrame = frame
+
+      let output = formatIndeterminateOutput(config, data.title, data.lenTitle,
+          columns, elapsed)
+      when defined(emscripten):
+        wasmProgressWrite(output.cstring)
+      else:
+        stdout.write(output & "\r")
+        stdout.flushFile()
+      sleep(sleepRate)
+      continue
 
     let currentProgress = data.progress.load()
     if currentProgress == lastProgress:
@@ -196,34 +272,39 @@ func tick*(bar: Bar, index: float) =
   if not bar.hide:
     bar.threadData.progress.store(index)
 
-proc start*(bar: Bar, total: float, title: string) =
-  if bar.hide:
-    return
-
-  var lenTitle = 0
+func displayLen(title: string): int =
+  ## Display length of a title, excluding ANSI escape sequences.
   var inEscape = false
-
-  # Calculate display length excluding ANSI escape sequences
   for c in title:
     if not inEscape:
       if c == '\x1b': # ESC character
         inEscape = true
       else:
-        inc lenTitle
+        inc result
     elif c == 'm':
       inEscape = false
 
+proc beginBar(bar: Bar, title: string, total: float, indeterminate: bool) =
   when defined(windows):
     stdout.write("\x1b[?25l") # hide cursor to prevent visible jumps while drawing
     stdout.flushFile()
 
   bar.threadData.title = title
-  bar.threadData.lenTitle = lenTitle
+  bar.threadData.lenTitle = displayLen(title)
   bar.threadData.total.store(total)
   bar.threadData.progress.store(0.0)
   bar.threadData.begin = epochTime()
+  bar.threadData.indeterminate.store(indeterminate)
   bar.threadData.sleeping.store(false)
   bar.threadData.paused.store(false)
+
+proc start*(bar: Bar, total: float, title: string) =
+  if not bar.hide:
+    beginBar(bar, title, total, indeterminate = false)
+
+proc startIndeterminate*(bar: Bar, title: string) =
+  if not bar.hide:
+    beginBar(bar, title, 0.0, indeterminate = true)
 
 proc `end`*(bar: Bar) =
   if not bar.hide:


### PR DESCRIPTION
Add a Material-style single-band indeterminate animation to the progress bar, used where the total duration is unknown: audio/motion analysis with no usable stream or container duration, and audio rendering.