### PR TITLE
wasm: enable -msimd128 across all codec builds

### DIFF
--- a/ae.nimble
+++ b/ae.nimble
@@ -442,22 +442,23 @@ proc cmakeBuildWasm(package: Package, buildPath: string, kind: CrossKind = wasm3
           "-DWHISPER_SDL2=OFF", "-DWHISPER_BUILD_EXAMPLES=OFF",
           "-DWHISPER_BUILD_TESTS=OFF", "-DWHISPER_BUILD_SERVER=OFF",
         ]
+        # -msimd128 enables ggml's hand-written wasm SIMD paths
+        args &= @[
+          &"\"-DCMAKE_C_FLAGS=-msimd128{memArg}\"",
+          &"\"-DCMAKE_CXX_FLAGS=-msimd128{memArg}\"",
+        ]
         if kind == wasm64:
-          args &= @[
-            "\"-DCMAKE_C_FLAGS=-sMEMORY64=1\"",
-            "\"-DCMAKE_CXX_FLAGS=-sMEMORY64=1\"",
-            "\"-DCMAKE_EXE_LINKER_FLAGS=-sMEMORY64=1\"",
-          ]
+          args.add "\"-DCMAKE_EXE_LINKER_FLAGS=-sMEMORY64=1\""
       of "libsvtav1":
         args &= @[
           "-DBUILD_APPS=OFF", "-DBUILD_DEC=OFF", "-DBUILD_ENC=ON", "-DENABLE_NASM=OFF",
-          &"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory{memArg}\"",
-          &"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory{memArg}\"",
+          &"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory -msimd128{memArg}\"",
+          &"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory -msimd128{memArg}\"",
         ]
       else:
         args &= package.buildArguments
-        args &= @[&"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory{memArg}\"",
-                  &"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory{memArg}\""]
+        args &= @[&"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory -msimd128{memArg}\"",
+                  &"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory -msimd128{memArg}\""]
       exec "emcmake cmake " & sourceDir & " " & args.join(" ")
     exec "make -j4 && make install"
 
@@ -503,7 +504,7 @@ proc mesonBuild(package: Package, buildPath: string, kind: CrossKind) =
   if kind == wasm32 or kind == wasm64:
     mesonArgs.add "-Denable_asm=false"
     let memArg = if kind == wasm64: " -sMEMORY64=1" else: ""
-    mesonArgs.add &"-Dc_args=\"-matomics -mbulk-memory{memArg}\""
+    mesonArgs.add &"-Dc_args=\"-matomics -mbulk-memory -msimd128{memArg}\""
     if kind == wasm64:
       mesonArgs.add "-Dc_link_args=\"-sMEMORY64=1\""
     let bits = (if kind == wasm64: "64" else: "32")
@@ -563,8 +564,8 @@ proc x265Build(buildPath: string, kind: CrossKind) =
   ]
 
   if isWasm:
-    commonArgs.add(&"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory -pthread{memArg}\"")
-    commonArgs.add(&"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory -pthread{memArg}\"")
+    commonArgs.add(&"\"-DCMAKE_C_FLAGS=-matomics -mbulk-memory -msimd128 -pthread{memArg}\"")
+    commonArgs.add(&"\"-DCMAKE_CXX_FLAGS=-matomics -mbulk-memory -msimd128 -pthread{memArg}\"")
     if kind == wasm64:
       commonArgs.add("\"-DCMAKE_EXE_LINKER_FLAGS=-sMEMORY64=1\"")
 
@@ -671,19 +672,26 @@ proc autoconfBuildWasm(package: Package, buildPath: string, kind: CrossKind = wa
     case package.name
     of "x264":
       if not fileExists("config.mak"):
-        exec &"""CFLAGS="-matomics -mbulk-memory{memArg}" LDFLAGS="{ldFlags}" emconfigure {sourceDir}/configure --prefix="{buildPath}" --host={x264Host} --enable-static --disable-cli --disable-asm --disable-lsmash --disable-swscale --disable-ffms --extra-cflags="-s USE_PTHREADS=1" """
+        exec &"""CFLAGS="-matomics -mbulk-memory -msimd128{memArg}" LDFLAGS="{ldFlags}" emconfigure {sourceDir}/configure --prefix="{buildPath}" --host={x264Host} --enable-static --disable-cli --disable-asm --disable-interlaced --disable-lsmash --disable-swscale --disable-ffms --extra-cflags="-s USE_PTHREADS=1" """
+        # x264 has no wasm asm, so the C path is all we get. Its configure
+        # force-appends -fno-tree-vectorize last, which suppresses LLVM
+        # autovectorization. Rewrite it in-place to enable wasm SIMD and
+        # re-enable vectorization (must land after x264's flag to win).
+        let makPath = "config.mak"
+        writeFile(makPath, readFile(makPath).replace(
+          "-fno-tree-vectorize", "-msimd128 -mrelaxed-simd -ftree-vectorize"))
       exec "emmake make -j4"
       exec "make install"
     of "libvpx":
       if not fileExists("Makefile"):
-        exec &"""LDFLAGS="{ldFlags}" emconfigure {sourceDir}/configure --prefix="{buildPath}" --target=generic-gnu --disable-dependency-tracking --disable-runtime-cpu-detect --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --extra-cflags="-matomics -mbulk-memory{memArg}" """
+        exec &"""LDFLAGS="{ldFlags}" emconfigure {sourceDir}/configure --prefix="{buildPath}" --target=generic-gnu --disable-dependency-tracking --disable-runtime-cpu-detect --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --extra-cflags="-matomics -mbulk-memory -msimd128{memArg}" """
       makeInstall()
     else:
       # lame, opus — use package.buildArguments; opus also needs --disable-rtcd
       let extraArgs = if package.name == "opus": @["--disable-rtcd"] else: @[]
       if not fileExists("Makefile"):
         let args = (package.buildArguments & extraArgs).join(" ")
-        exec &"""emconfigure {sourceDir}/configure --prefix="{buildPath}" --enable-static --disable-shared {args} CFLAGS="-matomics -mbulk-memory{memArg}" LDFLAGS="{ldFlags}" """
+        exec &"""emconfigure {sourceDir}/configure --prefix="{buildPath}" --enable-static --disable-shared {args} CFLAGS="-matomics -mbulk-memory -msimd128{memArg}" LDFLAGS="{ldFlags}" """
       makeInstall()
 
 proc ffmpegSetup(buildPath: string): seq[Package] =
@@ -1058,8 +1066,8 @@ Cflags: -I${{includedir}}
       --enable-pthreads \
       --disable-w32threads \
       --disable-os2threads \
-      --extra-cflags="-I{buildPath}/include -matomics -mbulk-memory -pthread{memArg}" \
-      --extra-ldflags="-L{buildPath}/lib -matomics -mbulk-memory -pthread{memArg}" \""" & "\n" & setupCommonFlags(packages, kind))
+      --extra-cflags="-I{buildPath}/include -matomics -mbulk-memory -msimd128 -pthread{memArg}" \
+      --extra-ldflags="-L{buildPath}/lib -matomics -mbulk-memory -msimd128 -pthread{memArg}" \""" & "\n" & setupCommonFlags(packages, kind))
     makeInstall()
 
 task makeffwasm, "Build FFmpeg for WebAssembly (requires emscripten)":


### PR DESCRIPTION
x264 force-appends -fno-tree-vectorize last (no wasm asm exists), so its config.mak is rewritten to -msimd128 -mrelaxed-simd -ftree-vectorize. All other packages get -msimd128; audio stays bit-exact (no relaxed-simd).