### PR TITLE
Add blackdetect edit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@
  - 
 
 ## Fixes
- - 
+ - The `regex`, `subtitle`, and `word` edit methods now advance positional arguments, so `stream` and `ignore-case` work when passed by position (e.g. `(word "hi" 0 #f)`), not only as keywords.
+ - The `levels` command now accepts the `ignore-case` parameter for the `word`/`regex`/`subtitle` methods and honors case-folding (`word` is case-insensitive by default), matching `--edit`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Features
  - Add the `erosion` action (3x3 local-minimum filter, a gritty eaten-away look) and the `choke:[n]` action, which shrinks the alpha matte left by `colorkey`/`chromakey` inward by `n` pixels to cut off key-color spill fringe on overlay tracks.
+ - Add the `blackdetect` edit method, which marks frames as loud when at least `threshold` of their pixels are black. Wrap in `(not ...)` to cut black fades/dead air.
 
 ## Performance
  - 

--- a/docs/src/ref/edit.html
+++ b/docs/src/ref/edit.html
@@ -42,7 +42,7 @@
 <p>When you run:<p>
 <pre><code>auto-editor example.mp4 --edit audio:0.05,stream=0</code></pre>
 <p>You're writing the syntax-sugary equivalent of:</p>
-<pre><code>auto-editor example.mp4 --edit "(audio 0.05 #:stream 0)"</code></pre>
+<pre><code>auto-editor example.mp4 --edit "(audio 0.05 (= stream 0))"</code></pre>
 <p>All the edit methods are listed below:</p>
 <h2>Edit Methods</h2>
 <div id="audio" class="palet-block">
@@ -60,6 +60,14 @@
 <p class="mono">&nbsp;<span class="palet-var">width</span>:&nbsp;Natural&nbsp;=&nbsp;400</p>
 </div>
 <p>Scale the video to <span class="palet-var">width</span> pixels, convert to grayscale, apply a Gaussian blur of <span class="palet-var">blur</span> amount, then compare the difference with the previous frame.</p>
+
+<div id="blackdetect" class="palet-block">
+<p class="mono">(<b>blackdetect</b>&nbsp;<span class="palet-var">[threshold]</span>&nbsp;<span class="palet-var">[stream]</span>&nbsp;<span class="palet-var">[pixel-black]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
+<p class="mono">&nbsp;<span class="palet-var">threshold</span>:&nbsp;Threshold&nbsp;=&nbsp;0.98</p>
+<p class="mono">&nbsp;<span class="palet-var">stream</span>:&nbsp;Natural&nbsp;=&nbsp;0</p>
+<p class="mono">&nbsp;<span class="palet-var">pixel-black</span>:&nbsp;Float&nbsp;=&nbsp;0.10</p>
+</div>
+<p>Mark a frame as loud when at least <span class="palet-var">threshold</span> of its pixels are black, where a pixel counts as black when its grayscale luma is at or below <span class="palet-var">pixel-black</span>. Wrap in <span class="palet-var">not</span> to instead cut black frames (fades, dead air).</p>
 
 <div id="subtitle" class="palet-block">
 <p class="mono">(<b>subtitle</b>&nbsp;<span class="palet-var">pattern</span>&nbsp;<span class="palet-var">[stream]</span>&nbsp;<span class="palet-var">[ignore-case]</span>&nbsp;<span class="palet-var">[max-count]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>

--- a/src/analyze/blackdetect.nim
+++ b/src/analyze/blackdetect.nim
@@ -1,0 +1,77 @@
+import std/[math, options, strformat]
+
+import ../[av, cache, ffmpeg, log]
+import ../util/[bar, rational, dnorm16]
+import ./motion # reuse the generic VideoProcessor + videoPipeline frame pump
+
+iterator blackness*(processor: var VideoProcessor, pixelBlack: float32): Unorm16 =
+  ## Per-frame ratio of "black" pixels (gray luma <= pixelBlack). Mirrors
+  ## `motionness`: one value per timebase index, filling gaps between source frames.
+  var prevIndex: int64 = -1
+  let blackThres = uint8(round(clamp(pixelBlack, 0.0'f32, 1.0'f32) * 255.0'f32))
+
+  for filteredFrame in processor.videoPipeline("format=gray"):
+    let frameTime = (filteredFrame.pts * processor.formatCtx.streams[
+        processor.videoIndex].time_base).float64
+    let index = round(frameTime * processor.tb.float64).int64
+
+    let w = filteredFrame.width.int
+    let h = filteredFrame.height.int
+    let stride = filteredFrame.linesize[0].int
+    let data = cast[ptr UncheckedArray[uint8]](filteredFrame.data[0])
+
+    var blackCount = 0
+    for y in 0 ..< h:
+      let rowOff = y * stride
+      for x in 0 ..< w:
+        if data[rowOff + x] <= blackThres:
+          inc blackCount
+
+    let value = toUnorm16(float32(blackCount) / float32(w * h))
+    for i in 0 ..< index - prevIndex:
+      yield value
+    prevIndex = index
+
+proc blackdetect*(bar: Bar, container: InputContainer, path: string, tb: AVRational,
+    stream: int32, pixelBlack: float32): seq[Unorm16] =
+  let cacheArgs = &"{stream},{pixelBlack}"
+  if not noCache:
+    let cacheData = readCache[Unorm16](path, tb, "blackdetect", cacheArgs)
+    if cacheData.isSome:
+      return cacheData.get()
+
+  if stream < 0 or stream >= container.video.len:
+    error &"blackdetect: video stream '{stream}' does not exist."
+
+  let videoStream: ptr AVStream = container.video[stream]
+
+  var processor = VideoProcessor(
+    formatCtx: container.formatContext,
+    codecCtx: initDecoder(videoStream.codecpar),
+    tb: tb,
+    videoIndex: videoStream.index,
+  )
+
+  var inaccurateDur: float = 1024.0
+  var knownDur = true
+  if videoStream.duration != AV_NOPTS_VALUE and videoStream.time_base != AV_NOPTS_VALUE:
+    inaccurateDur = float(videoStream.duration) * float(videoStream.time_base * tb)
+  elif container.duration != 0.0:
+    inaccurateDur = container.duration / float(tb)
+  else:
+    knownDur = false
+
+  if knownDur:
+    bar.start(inaccurateDur, "Analyzing blackness")
+  else:
+    bar.startIndeterminate("Analyzing blackness")
+  var i: float = 0
+  for value in processor.blackness(pixelBlack):
+    result.add value
+    bar.tick(i)
+    i += 1
+
+  bar.`end`()
+
+  if not noCache:
+    writeCache(result, tb, path, "blackdetect", cacheArgs)

--- a/src/cmds/levels.nim
+++ b/src/cmds/levels.nim
@@ -6,7 +6,7 @@ import ../analyze/[audio, blackdetect, motion, subtitle]
 
 import ../vendor/tinyre/tinyre
 
-proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32) =
+proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32, bool) =
   var
     stream: int32 = 0
     pattern = ""
@@ -15,10 +15,12 @@ proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32) 
     pixelBlack: float32 = 0.10
 
   let colonPos = editStr.find(':')
-  if colonPos == -1:
-    return (editStr, pattern, stream, width, blur, pixelBlack)
+  let kind = if colonPos == -1: editStr else: editStr[0 ..< colonPos]
+  var ignoreCase = kind == "word"  # word matches case-insensitively by default
 
-  let kind = editStr[0 ..< colonPos]
+  if colonPos == -1:
+    return (kind, pattern, stream, width, blur, pixelBlack, ignoreCase)
+
   let paramsStr = editStr[colonPos+1..^1]
 
   var i = 0
@@ -70,6 +72,11 @@ proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32) 
       of "blur": blur = parseInt(value).int32
       of "pixel-black": pixelBlack = parseFloat(value).float32
       of "pattern": pattern = value
+      of "ignore-case":
+        case value
+        of "#t", "true": ignoreCase = true
+        of "#f", "false": ignoreCase = false
+        else: error &"Invalid boolean (expected true or false): {value}"
       of "threshold": error "threshold parameter not allowed for levels command"
       else: error &"Unknown parameter: {paramName}"
 
@@ -77,7 +84,7 @@ proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32) 
     if i < paramsStr.len and paramsStr[i] == ',':
       inc i
 
-  return (kind, pattern, stream, width, blur, pixelBlack)
+  return (kind, pattern, stream, width, blur, pixelBlack, ignoreCase)
 
 
 proc main*(strArgs: seq[string]) =
@@ -125,7 +132,7 @@ proc main*(strArgs: seq[string]) =
 
   av_log_set_level(AV_LOG_QUIET)
   let chunkDuration: float64 = av_inv_q(tb)
-  let (editMethod, pattern, userStream, width, blur, pixelBlack) = parseEdit(edit)
+  let (editMethod, pattern, userStream, width, blur, pixelBlack, ignoreCase) = parseEdit(edit)
 
   if editMethod notin ["audio", "motion", "blackdetect", "subtitle", "word", "regex"]:
     error &"Unknown editing method: {editMethod}"
@@ -219,9 +226,18 @@ proc main*(strArgs: seq[string]) =
     if container.subtitle.len == 0:
       error "No Subtitle stream"
 
+    # subtitle/regex match utf8; ignoreCase already carries word's default.
+    var flags: set[ReFlag]
+    if editMethod != "word":
+      flags.incl reUtf8
+    if ignoreCase:
+      flags.incl reIgnoreCase
+
     var regPattern: Re
     try:
-      regPattern = if editMethod == "word": re("\\b" & escapeRe(pattern) & "\\b") else: re(pattern)
+      regPattern =
+        if editMethod == "word": re("\\b" & escapeRe(pattern) & "\\b", flags)
+        else: re(pattern, flags)
     except ValueError:
       error &"Invalid regex expression: {pattern}"
 

--- a/src/cmds/levels.nim
+++ b/src/cmds/levels.nim
@@ -2,20 +2,21 @@ import std/[options, strformat, strutils]
 
 import ../util/[rational, dnorm16]
 import ../[av, cache, ffmpeg, log]
-import ../analyze/[audio, motion, subtitle]
+import ../analyze/[audio, blackdetect, motion, subtitle]
 
 import ../vendor/tinyre/tinyre
 
-proc parseEdit(editStr: string): (string, string, int32, int32, int32) =
+proc parseEdit(editStr: string): (string, string, int32, int32, int32, float32) =
   var
     stream: int32 = 0
     pattern = ""
     width: int32 = 400
     blur: int32 = 9
+    pixelBlack: float32 = 0.10
 
   let colonPos = editStr.find(':')
   if colonPos == -1:
-    return (editStr, pattern, stream, width, blur)
+    return (editStr, pattern, stream, width, blur, pixelBlack)
 
   let kind = editStr[0 ..< colonPos]
   let paramsStr = editStr[colonPos+1..^1]
@@ -67,6 +68,7 @@ proc parseEdit(editStr: string): (string, string, int32, int32, int32) =
       of "stream": stream = parseInt(value).int32
       of "width": width = parseInt(value).int32
       of "blur": blur = parseInt(value).int32
+      of "pixel-black": pixelBlack = parseFloat(value).float32
       of "pattern": pattern = value
       of "threshold": error "threshold parameter not allowed for levels command"
       else: error &"Unknown parameter: {paramName}"
@@ -75,7 +77,7 @@ proc parseEdit(editStr: string): (string, string, int32, int32, int32) =
     if i < paramsStr.len and paramsStr[i] == ',':
       inc i
 
-  return (kind, pattern, stream, width, blur)
+  return (kind, pattern, stream, width, blur, pixelBlack)
 
 
 proc main*(strArgs: seq[string]) =
@@ -123,14 +125,17 @@ proc main*(strArgs: seq[string]) =
 
   av_log_set_level(AV_LOG_QUIET)
   let chunkDuration: float64 = av_inv_q(tb)
-  let (editMethod, pattern, userStream, width, blur) = parseEdit(edit)
+  let (editMethod, pattern, userStream, width, blur, pixelBlack) = parseEdit(edit)
 
-  if editMethod notin ["audio", "motion", "subtitle", "word", "regex"]:
+  if editMethod notin ["audio", "motion", "blackdetect", "subtitle", "word", "regex"]:
     error &"Unknown editing method: {editMethod}"
   if userStream < 0:
     error "Stream must be positive"
 
-  let cacheArgs = if editMethod == "audio": $userStream else: &"{userStream},{width},{blur}"
+  let cacheArgs =
+    if editMethod == "audio": $userStream
+    elif editMethod == "blackdetect": &"{userStream},{pixelBlack}"
+    else: &"{userStream},{width},{blur}"
 
   template emit(u: Unorm16) =
     if display == "d16": echo uint16(u) else: echo u
@@ -187,6 +192,25 @@ proc main*(strArgs: seq[string]) =
     )
 
     for u in processor.motionness(width, blur):
+      emit u
+      data.add u
+    echo ""
+
+  elif editMethod == "blackdetect":
+    if container.video.len == 0:
+      error "No video stream"
+    if container.video.len <= userStream:
+      error &"Video stream out of range: {userStream}"
+
+    let videoStream: ptr AVStream = container.video[userStream]
+    var processor = VideoProcessor(
+      formatCtx: container.formatContext,
+      codecCtx: initDecoder(videoStream.codecpar),
+      tb: tb,
+      videoIndex: videoStream.index,
+    )
+
+    for u in processor.blackness(pixelBlack):
       emit u
       data.add u
     echo ""

--- a/src/edit.nim
+++ b/src/edit.nim
@@ -340,6 +340,9 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
               flags.incl reIgnoreCase
           else: error "Too many args"
 
+          if not isKey:
+            argPos += 1
+
         if pattern == "":
           error &"{text[node[0].`from` ..< node[0].to]}: pattern required"
 
@@ -378,6 +381,9 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
           of 1: stream = parseNat(val)
           of 2: ignoreCase = parseBool(val)
           else: error "Too many args"
+
+          if not isKey:
+            argPos += 1
 
         if pattern == "":
           error "word: value required"

--- a/src/edit.nim
+++ b/src/edit.nim
@@ -1,6 +1,6 @@
 import std/[math, options, os, sequtils, strformat, strutils]
 import ./[av, editlexer, ffmpeg, log]
-import ./analyze/[audio, motion, subtitle]
+import ./analyze/[audio, blackdetect, motion, subtitle]
 import ./util/[bar, dnorm16, fun, rational]
 
 import ./vendor/tinyre/tinyre
@@ -47,6 +47,7 @@ proc orWithThreshold(result: var seq[bool], levels: seq[Unorm16], t: Unorm16) =
 const
   defaultAudioThres = toUnorm16(0.04)
   defaultMotionThres = toUnorm16(0.02)
+  defaultBlackThres = toUnorm16(0.98)
 
 proc parseThres(val: string): Unorm16 =
   let (num, unit) = splitNumStr(val)
@@ -204,7 +205,7 @@ proc editNeeds*(edit: string): tuple[video, audio: bool] =
         walk(head)
     elif e.kind == ExprSym:
       case edit[e.`from` ..< e.to]:
-      of "motion", "subtitle", "regex", "word": video = true
+      of "motion", "blackdetect", "subtitle", "regex", "word": video = true
       of "audio": audio = true
       else: discard
 
@@ -303,6 +304,26 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
 
         for ci in 0 ..< containers.len:
           result.orWithThreshold(motion(bar, containers[ci], args.inputs[ci], tb, stream, width, blur), threshold)
+        return result
+      of "blackdetect":
+        threshold = defaultBlackThres
+        var pixelBlack: float32 = 0.10
+        let argOrder = @["threshold", "stream", "pixel-black"]
+
+        for expr in node[1 ..< node.len]:
+          let val = parseColFunc(argPos, isKey, argOrder, expr, text)
+
+          case argPos:
+          of 0: threshold = parseThres(val)
+          of 1: stream = parseNat(val)
+          of 2: pixelBlack = parseFloatInRange(val, 0.0, 1.0)
+          else: error "Too many args"
+
+          if not isKey:
+            argPos += 1
+
+        for ci in 0 ..< containers.len:
+          result.orWithThreshold(blackdetect(bar, containers[ci], args.inputs[ci], tb, stream, pixelBlack), threshold)
         return result
       of "subtitle", "regex":
         let argOrder = @["pattern", "stream", "ignore-case"] # "max-count"]


### PR DESCRIPTION
Per-frame black-pixel ratio via the shared motion VideoProcessor, thresholded like motion/audio. Black = active, so compose with `not` to cut fades/dead air.