### PR TITLE
Generate edit reference from a single source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@
 ## Fixes
  - The `regex`, `subtitle`, and `word` edit methods now advance positional arguments, so `stream` and `ignore-case` work when passed by position (e.g. `(word "hi" 0 #f)`), not only as keywords.
  - The `levels` command now accepts the `ignore-case` parameter for the `word`/`regex`/`subtitle` methods and honors case-folding (`word` is case-insensitive by default), matching `--edit`.
+ - The Edit Reference page is now generated from the source, so it documents `word`, `regex`, `xor`, and `not` (previously omitted), corrects `motion`'s argument order, and drops the unimplemented `max-count`.
+ - URL inputs edited with only `subtitle`/`word`/`regex` no longer download the full video; these methods read the subtitle stream, so just audio is fetched.

--- a/docs/components/gen_edit.nims
+++ b/docs/components/gen_edit.nims
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S nim e --hints:off
+mode = ScriptMode.Silent
+
+import std/[strformat, strutils]
+import ../../src/editmethods
+
+const ret = "BoolArray"
+
+func htmlHelp(s: string): string =
+  ## Render `name` (backtick-wrapped param refs) as edit-var spans.
+  var inCode = false
+  for c in s:
+    if c == '`':
+      result.add(if inCode: "</span>" else: "<span class=\"edit-var\">")
+      inCode = not inCode
+    else:
+      result.add c
+
+func sigArg(prm: EditParam): string =
+  let label = if prm.default == "": prm.name else: "[" & prm.name & "]"
+  &"<span class=\"edit-var\">{label}</span>"
+
+func defaultVal(d: string): string =
+  if d.startsWith("#") or d == "nil": &"<span class=\"edit-val\">{d}</span>"
+  else: d
+
+proc renderMethod(d: EditMethodDef): string =
+  var sig = ""
+  for name in d.names:
+    sig.add &"(<b>{name}</b>"
+    for prm in d.params:
+      sig.add "&nbsp;" & sigArg(prm)
+    sig.add &")&nbsp;→&nbsp;{ret}<br>"
+
+  result.add &"<div id=\"{d.names[0]}\" class=\"edit-block\">\n"
+  result.add &"<p class=\"mono\">{sig}</p>\n"
+  for prm in d.params:
+    var line = &"&nbsp;<span class=\"edit-var\">{prm.name}</span>:&nbsp;{prm.typ}"
+    if prm.default != "":
+      line.add &"&nbsp;=&nbsp;{defaultVal(prm.default)}"
+    result.add &"<p class=\"mono\">{line}</p>\n"
+  result.add "</div>\n"
+  result.add &"<p>{htmlHelp(d.help)}</p>\n\n"
+
+proc renderOperator(o: EditOperatorDef): string =
+  var sig = &"(<b>{o.name}</b>&nbsp;<span class=\"edit-var\">operand</span>"
+  if o.variadic:
+    sig.add "&nbsp;<span class=\"edit-var\">...</span>"
+  sig.add &")&nbsp;→&nbsp;{ret}"
+
+  result.add &"<div id=\"{o.name}\" class=\"edit-block\">\n"
+  result.add &"<p class=\"mono\">{sig}</p>\n"
+  result.add &"<p class=\"mono\">&nbsp;<span class=\"edit-var\">operand</span>:&nbsp;{ret}</p>\n"
+  result.add "</div>\n"
+  result.add &"<p>{htmlHelp(o.help)}</p>\n\n"
+
+var output = "<h2>Edit Methods</h2>\n"
+for d in editMethodDefs:
+  output.add renderMethod(d)
+
+output.add "<h2>Operators</h2>\n"
+for o in editOperatorDefs:
+  output.add renderOperator(o)
+
+echo output

--- a/docs/src/ref/edit.html
+++ b/docs/src/ref/edit.html
@@ -7,30 +7,30 @@
 {{ head_icon }}
 <style>
 {{ core_style }}
-.palet-block {
+.edit-block {
  padding-left: 7px;
  padding-bottom: 7px;
  padding-top: 7px;
  margin-top: 30px;
  margin-bottom: 6px;
 }
-.palet-block > p {margin-top: 0; margin-bottom: 0}
-.palet-var {
+.edit-block > p {margin-top: 0; margin-bottom: 0}
+.edit-var {
     position: relative;
     left: -1px;
     font-size: 85%;
     font-style: italic;
     font-family: SFMono-Regular, ui-monospace, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
 }
-.palet-val {
+.edit-val {
     color: #0B65B8;
     font-size: 85%;
     font-family: SFMono-Regular, ui-monospace, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
 }
-.palet-block { background-color: #F9F5F5; border-top: 3px solid #EAEAEA}
+.edit-block { background-color: #F9F5F5; border-top: 3px solid #EAEAEA}
 @media (prefers-color-scheme: dark) {
-  .palet-block {background-color: #323232; border-top: 3px solid #4A4A4A}
-  .palet-val {color: #A3DEFF}
+  .edit-block {background-color: #323232; border-top: 3px solid #4A4A4A}
+  .edit-val {color: #A3DEFF}
 }
 </style>
 </head>
@@ -44,52 +44,7 @@
 <p>You're writing the syntax-sugary equivalent of:</p>
 <pre><code>auto-editor example.mp4 --edit "(audio 0.05 (= stream 0))"</code></pre>
 <p>All the edit methods are listed below:</p>
-<h2>Edit Methods</h2>
-<div id="audio" class="palet-block">
-<p class="mono">(<b>audio</b>&nbsp;<span class="palet-var">[threshold]</span>&nbsp;<span class="palet-var">[stream]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">threshold</span>:&nbsp;Threshold&nbsp;=&nbsp;0.04</p>
-<p class="mono">&nbsp;<span class="palet-var">stream</span>:&nbsp;(U Natural 'all)&nbsp;=&nbsp;'all</p>
-</div>
-<p>Do a one-pass audio filter based on loudest sample in a timebase section, divided by the max value a sample can be.</p>
-
-<div id="motion" class="palet-block">
-<p class="mono">(<b>motion</b>&nbsp;<span class="palet-var">[threshold]</span>&nbsp;<span class="palet-var">[stream]</span>&nbsp;<span class="palet-var">[blur]</span>&nbsp;<span class="palet-var">[width]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">threshold</span>:&nbsp;Threshold&nbsp;=&nbsp;0.02</p>
-<p class="mono">&nbsp;<span class="palet-var">stream</span>:&nbsp;Natural&nbsp;=&nbsp;0</p>
-<p class="mono">&nbsp;<span class="palet-var">blur</span>:&nbsp;Natural&nbsp;=&nbsp;9</p>
-<p class="mono">&nbsp;<span class="palet-var">width</span>:&nbsp;Natural&nbsp;=&nbsp;400</p>
-</div>
-<p>Scale the video to <span class="palet-var">width</span> pixels, convert to grayscale, apply a Gaussian blur of <span class="palet-var">blur</span> amount, then compare the difference with the previous frame.</p>
-
-<div id="blackdetect" class="palet-block">
-<p class="mono">(<b>blackdetect</b>&nbsp;<span class="palet-var">[threshold]</span>&nbsp;<span class="palet-var">[stream]</span>&nbsp;<span class="palet-var">[pixel-black]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">threshold</span>:&nbsp;Threshold&nbsp;=&nbsp;0.98</p>
-<p class="mono">&nbsp;<span class="palet-var">stream</span>:&nbsp;Natural&nbsp;=&nbsp;0</p>
-<p class="mono">&nbsp;<span class="palet-var">pixel-black</span>:&nbsp;Float&nbsp;=&nbsp;0.10</p>
-</div>
-<p>Mark a frame as loud when at least <span class="palet-var">threshold</span> of its pixels are black, where a pixel counts as black when its grayscale luma is at or below <span class="palet-var">pixel-black</span>. Wrap in <span class="palet-var">not</span> to instead cut black frames (fades, dead air).</p>
-
-<div id="subtitle" class="palet-block">
-<p class="mono">(<b>subtitle</b>&nbsp;<span class="palet-var">pattern</span>&nbsp;<span class="palet-var">[stream]</span>&nbsp;<span class="palet-var">[ignore-case]</span>&nbsp;<span class="palet-var">[max-count]</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">pattern</span>:&nbsp;String</p>
-<p class="mono">&nbsp;<span class="palet-var">stream</span>:&nbsp;Natural&nbsp;=&nbsp;0</p>
-<p class="mono">&nbsp;<span class="palet-var">ignore-case</span>:&nbsp;Bool&nbsp;=&nbsp;<span class="palet-val">#f</span></p>
-<p class="mono">&nbsp;<span class="palet-var">max-count</span>:&nbsp;(U Natural Nil)&nbsp;=&nbsp;<span class="palet-val">nil</span></p>
-</div>
-<p>When <span class="palet-var">pattern</span>, a RegEx Expression, matches a subtitle line, consider that time the line occupies as loud.</p>
-
-<h2>Operators</h2>
-<div id="or" class="palet-block">
-<p class="mono">(<b>or</b>&nbsp;<span class="palet-var">operand</span>&nbsp;<span class="palet-var">...</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">operand</span>:&nbsp;<a href="#bool-array?">bool-array?</a></p>
-</div>
-<p>"Logical Or" two or more boolean arrays. If they are different lengths, use the biggest one.</p>
-
-<div id="and" class="palet-block">
-<p class="mono">(<b>and</b>&nbsp;<span class="palet-var">operand</span>&nbsp;<span class="palet-var">...</span>)&nbsp;→&nbsp;<a href="#bool-array?">bool-array?</a>&nbsp;&nbsp;Procedure</p>
-<p class="mono">&nbsp;<span class="palet-var">operand</span>:&nbsp;<a href="#bool-array?">bool-array?</a></p>
-</div>
-<p>"Logical And" two or more boolean arrays.</p>
+{{ exec gen_edit.nims }}
 </div>
 </section>
 </body>

--- a/src/edit.nim
+++ b/src/edit.nim
@@ -1,5 +1,5 @@
 import std/[math, options, os, sequtils, strformat, strutils]
-import ./[av, editlexer, ffmpeg, log]
+import ./[av, editlexer, editmethods, ffmpeg, log]
 import ./analyze/[audio, blackdetect, motion, subtitle]
 import ./util/[bar, dnorm16, fun, rational]
 
@@ -177,8 +177,9 @@ proc findExternSubs(input: string): Option[InputContainer] {.raises: [].} =
       none(InputContainer)
 
 proc editNeeds*(edit: string): tuple[video, audio: bool] =
-  ## Report which media streams an --edit expression analyzes, so callers can
-  ## avoid fetching streams that no editing method will look at.
+  ## Report whether an --edit expression analyzes video and/or audio frames, so
+  ## callers can avoid fetching streams no editing method will look at. Subtitle
+  ## methods read the subtitle stream, so they report neither.
   var lexer = initLexer("--edit", edit)
   var parser = initParser(lexer)
   let expressions =
@@ -197,17 +198,17 @@ proc editNeeds*(edit: string): tuple[video, audio: bool] =
       if e.elements.len == 0:
         return
       let head = e.elements[0]
-      if head.kind == ExprSym and
-          edit[head.`from` ..< head.to] in ["or", "and", "xor", "not"]:
+      if head.kind == ExprSym and isEditOperator(edit[head.`from` ..< head.to]):
         for i in 1 ..< e.elements.len:
           walk(e.elements[i])
       else:
         walk(head)
     elif e.kind == ExprSym:
-      case edit[e.`from` ..< e.to]:
-      of "motion", "blackdetect", "subtitle", "regex", "word": video = true
-      of "audio": audio = true
-      else: discard
+      for m in editMediaOf(edit[e.`from` ..< e.to]):
+        case m
+        of emVideo: video = true
+        of emAudio: audio = true
+        of emSubtitle: discard # analyzed from the subtitle stream, not v/a frames
 
   walk(expressions[^1])
   return (video, audio)
@@ -263,7 +264,7 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
         return not editEval(node[1], text)
       of "audio":
         stream = -1 # Set to "all" by default
-        let argOrder = @["threshold", "stream"]
+        let argOrder = argOrderOf("audio")
 
         for expr in node[1 ..< node.len]:
           let val = parseColFunc(argPos, isKey, argOrder, expr, text)
@@ -287,7 +288,7 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
         return result
       of "motion":
         threshold = defaultMotionThres
-        let argOrder = @["threshold", "stream", "width", "blur"]
+        let argOrder = argOrderOf("motion")
 
         for expr in node[1 ..< node.len]:
           let val = parseColFunc(argPos, isKey, argOrder, expr, text)
@@ -308,7 +309,7 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
       of "blackdetect":
         threshold = defaultBlackThres
         var pixelBlack: float32 = 0.10
-        let argOrder = @["threshold", "stream", "pixel-black"]
+        let argOrder = argOrderOf("blackdetect")
 
         for expr in node[1 ..< node.len]:
           let val = parseColFunc(argPos, isKey, argOrder, expr, text)
@@ -326,7 +327,7 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
           result.orWithThreshold(blackdetect(bar, containers[ci], args.inputs[ci], tb, stream, pixelBlack), threshold)
         return result
       of "subtitle", "regex":
-        let argOrder = @["pattern", "stream", "ignore-case"] # "max-count"]
+        let argOrder = argOrderOf("subtitle")
         var pattern = ""
         var flags = {reUtf8}
 
@@ -369,7 +370,7 @@ proc interpretEdit*(args: mainArgs, containers: seq[InputContainer], tb: AVRatio
             result = result or subResult
         return result
       of "word":
-        let argOrder = @["value", "stream", "ignore-case"]
+        let argOrder = argOrderOf("word")
         var pattern = ""
         var ignoreCase = true
         var flags: set[ReFlag]

--- a/src/editmethods.nim
+++ b/src/editmethods.nim
@@ -1,0 +1,98 @@
+## Single source of truth for `--edit` methods and operators.
+##
+## `src/edit.nim` derives each method's positional argument order and which
+## stream it analyzes from these defs; `docs/components/gen_edit.nims`
+## renders the Edit Reference page from them. Keep this module dependency-light
+## (std-only) so the docs generator can import it without pulling in ffmpeg.
+
+type
+  EditMedia* = enum
+    emVideo, emAudio, emSubtitle
+
+  EditParam* = object
+    name*: string     ## positional argument name, e.g. "threshold"
+    typ*: string      ## doc type, e.g. "(U Natural 'all)"
+    default*: string  ## doc default; "" means the argument is required
+
+  EditMethodDef* = object
+    names*: seq[string]      ## canonical name first, then aliases (share parsing)
+    media*: EditMedia        ## which stream the method analyzes
+    params*: seq[EditParam]
+    help*: string
+
+  EditOperatorDef* = object
+    name*: string
+    variadic*: bool          ## true => `operand ...`
+    help*: string
+
+func p(name, typ: string, default = ""): EditParam =
+  EditParam(name: name, typ: typ, default: default)
+
+const editMethodDefs*: seq[EditMethodDef] = @[
+  EditMethodDef(names: @["audio"], media: emAudio,
+    params: @[p("threshold", "Unorm16", "0.04"),
+              p("stream", "(U Natural 'all)", "all")],
+    help: "Do a one-pass audio filter based on the loudest sample in a " &
+          "timebase section, divided by the max value a sample can be."),
+  EditMethodDef(names: @["motion"], media: emVideo,
+    params: @[p("threshold", "Unorm16", "0.02"),
+              p("stream", "Natural", "0"),
+              p("width", "Natural", "400"),
+              p("blur", "Natural", "9")],
+    help: "Scale the video to `width` pixels, convert to grayscale, apply a " &
+          "Gaussian blur of `blur` amount, then compare the difference with " &
+          "the previous frame."),
+  EditMethodDef(names: @["blackdetect"], media: emVideo,
+    params: @[p("threshold", "Unorm16", "0.98"),
+              p("stream", "Natural", "0"),
+              p("pixel-black", "Float", "0.10")],
+    help: "Mark a frame as loud when at least `threshold` of its pixels are " &
+          "black, where a pixel counts as black when its grayscale luma is at " &
+          "or below `pixel-black`. Wrap in `not` to instead cut black frames."),
+  EditMethodDef(names: @["subtitle", "regex"], media: emSubtitle,
+    params: @[p("pattern", "String"),
+              p("stream", "Natural", "0"),
+              p("ignore-case", "Bool", "#f")],
+    help: "When `pattern`, a RegEx expression, matches a subtitle line, " &
+          "consider the time that line occupies as loud."),
+  EditMethodDef(names: @["word"], media: emSubtitle,
+    params: @[p("value", "String"),
+              p("stream", "Natural", "0"),
+              p("ignore-case", "Bool", "#t")],
+    help: "When `value`, matched as a whole word, appears in a subtitle line, " &
+          "consider the time that line occupies as loud. Case-insensitive by " &
+          "default."),
+]
+
+const editOperatorDefs*: seq[EditOperatorDef] = @[
+  EditOperatorDef(name: "or", variadic: true,
+    help: "\"Logical Or\" two or more boolean arrays. If they are different " &
+          "lengths, use the biggest one."),
+  EditOperatorDef(name: "and", variadic: true,
+    help: "\"Logical And\" two or more boolean arrays. If they are different " &
+          "lengths, use the smallest one."),
+  EditOperatorDef(name: "xor", variadic: true,
+    help: "\"Logical Xor\" two or more boolean arrays."),
+  EditOperatorDef(name: "not", variadic: false,
+    help: "Invert a boolean array."),
+]
+
+func argOrderOf*(name: string): seq[string] =
+  ## Positional argument names for the method whose canonical name or alias is
+  ## `name`. Empty if no such method.
+  for d in editMethodDefs:
+    if name in d.names:
+      for prm in d.params:
+        result.add prm.name
+      return
+
+func editMediaOf*(name: string): set[EditMedia] =
+  ## The stream(s) an edit method analyzes; empty for unknown names/operators.
+  for d in editMethodDefs:
+    if name in d.names:
+      return {d.media}
+
+func isEditOperator*(name: string): bool =
+  for o in editOperatorDefs:
+    if o.name == name:
+      return true


### PR DESCRIPTION
Edit methods were duplicated between edit.nim and hand-written edit.html. Move defs to editmethods.nim; edit.nim derives argOrder/ editNeeds from it, gen_edit.nims renders the docs page.