### PR TITLE
Add chromatic aberration action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Add the `erosion` action (3x3 local-minimum filter, a gritty eaten-away look) and the `choke:[n]` action, which shrinks the alpha matte left by `colorkey`/`chromakey` inward by `n` pixels to cut off key-color spill fringe on overlay tracks.
  - Add the `blackdetect` edit method, which marks frames as loud when at least `threshold` of their pixels are black. Wrap in `(not ...)` to cut black fades/dead air.
  - Add the `aberration` action, which fakes chromatic aberration by shifting the color channels apart for a cheap-lens/glitch color-fringing look. Use the shorthand `aberration[:h[:v[:edge]]]` for a symmetric red/blue split (horizontal `h`, vertical `v`, `edge` of `smear`/`wrap`), or `key=value` pairs (`rh rv gh gv bh bv edge`) for full per-channel control, e.g. `aberration:rh=8:bh=-8:gv=2:edge=wrap`.
+ - The `pos` action is now animatable: each of `x`, `y`, and `scale` takes a keyframe ramp (`pos:0..600:300:1..0.5`) with optional easing, so an overlay can slide and resize across a section. The `add:path:x:y:scale` placement fields accept the same ramps (`add:logo.png:0..1000:300:1..0.5`). Overlays are placed at sub-pixel positions, so slow motion slides smoothly instead of stair-stepping.
 
 ## Performance
  - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Features
  - Add the `erosion` action (3x3 local-minimum filter, a gritty eaten-away look) and the `choke:[n]` action, which shrinks the alpha matte left by `colorkey`/`chromakey` inward by `n` pixels to cut off key-color spill fringe on overlay tracks.
  - Add the `blackdetect` edit method, which marks frames as loud when at least `threshold` of their pixels are black. Wrap in `(not ...)` to cut black fades/dead air.
+ - Add the `aberration` action, which fakes chromatic aberration by shifting the color channels apart for a cheap-lens/glitch color-fringing look. Use the shorthand `aberration[:h[:v[:edge]]]` for a symmetric red/blue split (horizontal `h`, vertical `v`, `edge` of `smear`/`wrap`), or `key=value` pairs (`rh rv gh gv bh bv edge`) for full per-channel control, e.g. `aberration:rh=8:bh=-8:gv=2:edge=wrap`.
 
 ## Performance
  - 

--- a/ae.nimble
+++ b/ae.nimble
@@ -811,7 +811,7 @@ proc setupCommonFlags(packages: seq[Package], kind: CrossKind = native): string 
 
   let enableDemuxers = enableMuxers & @["image2", "png_pipe", "mpegts"]
 
-  var filters = "aformat,abuffer,abuffersink,aresample,asetrate,atempo,anull,anullsrc,chromakey,colorkey,crop,drawbox,deesser,erosion,format,gblur,hflip,lenscorrection,loudnorm,lut,lutrgb,lutyuv,negate,overlay,pad,rotate,scale,vflip,volume".split(",")
+  var filters = "aformat,abuffer,abuffersink,aresample,asetrate,atempo,anull,anullsrc,chromakey,colorkey,crop,drawbox,deesser,erosion,format,gblur,hflip,lenscorrection,loudnorm,lut,lutrgb,lutyuv,negate,overlay,pad,rgbashift,rotate,scale,vflip,volume".split(",")
 
   for package in packages:
     if package.name == "libvpx":

--- a/docs/src/docs/actions.md
+++ b/docs/src/docs/actions.md
@@ -217,7 +217,8 @@ Overlay an image or video on top of the matched sections, `add:path` or
   for the whole section.
 - **x**, **y**, **scale** — optional placement, applied via a `pos` action
   (above). When omitted, the overlay is scaled to fit the canvas (preserving
-  aspect ratio) and centered, like a full-frame layer.
+  aspect ratio) and centered, like a full-frame layer. Each may be a **ramp**
+  (e.g. `0..600`), so the overlay animates across the section.
 
 ```bash
 # Overlay a logo scaled to fit and centered over every kept (normal) section
@@ -225,6 +226,9 @@ auto-editor video.mp4 --when-normal add:./logo.png
 
 # Put a logo at (600, 300)
 auto-editor video.mp4 --when-normal add:./logo.png:600:300:1.0
+
+# Slide a logo across the frame while shrinking it (ramps in x and scale)
+auto-editor video.mp4 --when-normal add:./logo.png:0..1000:300:1..0.5
 
 # Shrink an overlay video to a quarter size in the corner
 auto-editor video.mp4 --when-normal add:./pip.mp4:900:60:0.25
@@ -281,6 +285,9 @@ plus `volume` for audio — accept a **ramp** instead of a single value, written
 over time. (For rotation, use the constant-speed `rotate:deg/rate` form
 described above.)
 
+`pos` is animatable too: each of its `x`, `y`, and `scale` fields takes its own
+ramp, so an overlay can slide and resize across the section.
+
 ```bash
 # Slowly zoom in from 1x to 1.5x across the section (Ken Burns)
 auto-editor video.mp4 --when-normal zoom:1..1.5
@@ -290,6 +297,9 @@ auto-editor video.mp4 --when-normal opacity:0..1
 
 # Fade the audio in alongside it
 auto-editor video.mp4 --when-normal volume:0..1
+
+# Slide a logo across the frame while shrinking it
+auto-editor video.mp4 --when-normal add:./logo.png,pos:0..1200:40:1..0.5
 ```
 
 The ramp reaches `to` on the section's last frame.

--- a/src/action.nim
+++ b/src/action.nim
@@ -6,11 +6,18 @@ template writeAt(baseBuffer: auto, index: int, offset: int, val: untyped) =
   copyMem(addr baseBuffer[index + offset], addr temp, sizeof(temp))
 
 type
+  # The order is part of the API
   ActionKind* = enum
-    actSpeed, actVarispeed, actVolume, actDeesser, actInvert, actHflip, actVflip,
-    actZoom, actOpacity, actBlur, actBrightness, actLuv, actLens, actRotate, actSpin,
-    actDrawbox, actPos, actColorKey, actChromaKey, actLoop, actErosion, actChoke,
-    actAberration
+    actSpeed, actVarispeed,
+    # Can add 2 more [VA] actions
+    actVolume = 4,
+    actDeesser,
+    # Can add 14 more [A] actions
+    actInvert = 20,
+    actHflip, actVflip, actZoom, actOpacity, actBlur, actBrightness, actLuv, actLens,
+    actRotate, actSpin, actDrawbox, actPos, actColorKey, actChromaKey, actLoop,
+    actErosion, actChoke, actAberration
+    # Can add 89 more [V] actions
 
   Easing* = enum  # interpolation curve for animations
     easeLinear, easeIn, easeOut, easeInOut

--- a/src/action.nim
+++ b/src/action.nim
@@ -24,6 +24,13 @@ type
   # keyframes (one value = static, several = a ramp interpolated across the
   # section) plus an optional easing curve + duration packed inline.
   Action* = object
+    # Easing envelope shared by every animatable action (zoom/blur/opacity/
+    # brightness/volume/pos). Defaults (off, linear, whole-clip) make a static
+    # action sample trivially, so non-animated actions just ignore these.
+    hasEase*: bool
+    easeCurve*: Easing
+    easeDurUnit*: DurUnit
+    easeDur*: float32        # magnitude in easeDurUnit (ignored for duClip)
     case kind*: ActionKind
     of actInvert, actHflip, actVflip, actLoop, actErosion:
       discard
@@ -40,10 +47,6 @@ type
       val*: float32
     of actZoom, actBlur, actOpacity, actBrightness, actVolume:
       kf*: seq[float32]      # keyframes in native units; len >= 1
-      hasEase*: bool
-      easeCurve*: Easing
-      easeDurUnit*: DurUnit
-      easeDur*: float32      # magnitude in easeDurUnit (ignored for duClip)
     of actDeesser:
       intensity*, maxd*, freq*: Unorm16
     of actLuv:
@@ -54,8 +57,9 @@ type
       dbX*, dbY*, dbW*, dbH*: int32   # rectangle in pixels (x, y, width, height)
       dbColor*: RGBColor              # outline color (RGB only)
     of actPos:
-      px*, py*: int32        # overlay top-left in canvas pixels
-      pscale*: float32       # overlay size multiplier (1.0 = native)
+      # Overlay placement ramps: top-left x/y in canvas px and a size multiplier
+      # (1.0 = native). Each is a keyframe seq (len 1 = static) like the scalars.
+      pxKf*, pyKf*, pscaleKf*: seq[float32]
     of actColorKey, actChromaKey:
       color*: RGBColor
       similar*, blend*: Unorm16
@@ -148,8 +152,8 @@ Positional args: `intensity` sets how much to de-ess (0.0 = none, 1.0 = maximum)
     help: "Spin the picture continuously, starting at `deg` and turning at `rate` degrees per second (negative is counter-clockwise), e.g. `spin:0/120`. The picture spins within a constant square that contains every rotation (so it is never clipped); on an overlay the exposed corners are transparent, otherwise they are filled with the background color."),
   ActionDef(name: "drawbox", flags: {afVideo}, argSpec: "x:y:w:h:color",
     help: "Draw a filled rectangle onto the picture. Positional args: `x` and `y` are the top-left corner, `w` and `h` the width and height in pixels, and `color` an RGB color (a name like `red` or a hex value like `#ff0000`). Example: `drawbox:100:100:400:200:red`. Implemented via ffmpeg's `drawbox` filter."),
-  ActionDef(name: "pos", flags: {afVideo}, argSpec: "x:y[:scale]",
-    help: "Place this clip as an overlay when it is composited over a lower video track. `x` and `y` are the top-left corner in canvas pixels; the optional `scale` multiplies the source's native size (default 1.0). Has no effect on the base (bottom) track. Example: `pos:600:300:0.5`."),
+  ActionDef(name: "pos", flags: {afVideo, afAnimatable}, argSpec: "x:y[:scale]",
+    help: "Place this clip as an overlay when it is composited over a lower video track. `x` and `y` are the top-left corner in canvas pixels; the optional `scale` multiplies the source's native size (default 1.0). Has no effect on the base (bottom) track. Example: `pos:600:300:0.5`. Animatable: each of `x`, `y`, and `scale` accepts a keyframe ramp `a..b..c` interpolated across the section, optionally eased with `:ease=`, e.g. `pos:0..600:300:1..0.5:ease=inout` slides the overlay across while shrinking it."),
   ActionDef(name: "lens", flags: {afVideo}, argSpec: "k1[:k2]", range: rng(-1.0, 1.0, each = true),
     help: """
 Distort the picture like a camera lens. With no arguments, a fun fisheye is applied. Implemented via ffmpeg's `lenscorrection` filter.
@@ -241,7 +245,7 @@ func rotCode(deg: float32): uint16 =
   let frac = turns - floor(turns)
   uint16(int(round(frac * 65536.0'f32)) and 0xFFFF)
 
-proc parseKeyframes(spec: string): seq[float32] {.raises: [ActionParseError].} =
+proc parseKeyframes*(spec: string): seq[float32] {.raises: [ActionParseError].} =
   ## "2" -> @[2]; "1..0.5..1" -> @[1, 0.5, 1] (keyframes spread across the section).
   for part in spec.split(".."):
     try:
@@ -461,16 +465,35 @@ func parseAction*(val: string): Action {.raises: [ActionParseError].} =
     return Action(kind: actAberration, abRh: chk(rh), abRv: chk(rv),
       abGh: chk(gh), abGv: chk(gv), abBh: chk(bh), abBv: chk(bv), abWrap: wrap)
 
-  # pos: overlay placement "pos:x:y" or "pos:x:y:scale".
-  if parts[0] == "pos" and parts.len in {3, 4}:
-    try:
-      let scale = (if parts.len == 4: parseFloat(parts[3]).float32 else: 1.0'f32)
-      if scale <= 0.0'f32:
+  # pos: overlay placement, each field an animatable ramp:
+  #   pos:x:y   pos:x:y:scale   pos:0..600:300:1..0.5:ease=inout
+  if parts[0] == "pos":
+    if parts.len < 3:
+      raise newException(ActionParseError, "pos requires x:y[:scale]")
+    let xKf = parseKeyframes(parts[1])
+    let yKf = parseKeyframes(parts[2])
+    # parts[3] is the scale ramp unless it's the ease suffix.
+    var sKf = @[1.0'f32]
+    var idx = 3
+    if parts.len > 3 and not parts[3].startsWith("ease="):
+      sKf = parseKeyframes(parts[3])
+      idx = 4
+    for v in sKf:
+      if v <= 0.0'f32:
         raise newException(ActionParseError, "pos scale must be greater than 0.0")
-      return Action(kind: actPos, px: int32(parseInt(parts[1])),
-        py: int32(parseInt(parts[2])), pscale: scale)
-    except ValueError:
-      raise newException(ActionParseError, "Invalid pos value")
+    var hasE = false
+    var curve = easeLinear
+    var unit = duClip
+    var dur = 0.0'f32
+    if parts.len > idx:
+      if not parts[idx].startsWith("ease=") or parts.len > idx + 2:
+        raise newException(ActionParseError, "Unknown action: " & val)
+      hasE = true
+      curve = parseEasing(parts[idx])
+      if parts.len == idx + 2:
+        (dur, unit) = parseDuration(parts[idx + 1])
+    return Action(kind: actPos, pxKf: xKf, pyKf: yKf, pscaleKf: sKf,
+      hasEase: hasE, easeCurve: curve, easeDurUnit: unit, easeDur: dur)
 
   # Animatable scalar effects: a value or keyframe ramp, with optional easing:
   #   zoom:2   zoom:1..2   zoom:1..0.5..1   zoom:1..2:ease=inout:2sec
@@ -599,7 +622,13 @@ when not defined(nimscript):
     of actDrawbox:
       "drawbox:" & $act.dbX & ":" & $act.dbY & ":" & $act.dbW & ":" &
         $act.dbH & ":" & act.dbColor.toString
-    of actPos: "pos:" & $act.px & ":" & $act.py & ":" & $act.pscale
+    of actPos:
+      var xs, ys, ss: seq[string]
+      for v in act.pxKf: xs.add $int(round(v))   # x/y are whole pixels
+      for v in act.pyKf: ys.add $int(round(v))
+      for v in act.pscaleKf: ss.add $v
+      "pos:" & xs.join("..") & ":" & ys.join("..") & ":" & ss.join("..") &
+        easeSuffix(act)
     of actColorKey: "colorkey:" & act.color.toString & ":" & $act.similar & ":" & $act.blend
     of actChromaKey: "chromakey:" & act.color.toString & ":" & $act.similar & ":" & $act.blend
     of actChoke: "choke:" & $int(act.chokeN)
@@ -631,7 +660,7 @@ when not defined(nimscript):
     of actDeesser, actSpin: 7
     of actColorKey, actChromaKey, actAberration: 8
     of actLuv: 11
-    of actPos: 13
+    of actPos: 4 + easeBytes(a) + (a.pxKf.len + a.pyKf.len + a.pscaleKf.len) * 4
     of actDrawbox: 20
     of actBrightness, actOpacity: 2 + easeBytes(a) + a.kf.len * 2
     of actBlur, actZoom, actVolume: 2 + easeBytes(a) + a.kf.len * 4
@@ -716,13 +745,27 @@ when not defined(nimscript):
           yield Action(kind: actLuv, brighthue: bh, contrast: c, saturation: s)
           i += 11
         of actPos:
-          var x, y: int32
-          var sc: float32
-          copyMem(addr x, addr base[i + 1], sizeof(int32))
-          copyMem(addr y, addr base[i + 5], sizeof(int32))
-          copyMem(addr sc, addr base[i + 9], sizeof(float32))
-          yield Action(kind: actPos, px: x, py: y, pscale: sc)
-          i += 13
+          let hasEase = (base[i] and easeFlag) != 0'u8
+          var pos = i + 1
+          var act = Action(kind: actPos, hasEase: hasEase)
+          if hasEase:
+            act.easeCurve = Easing(base[pos].int)
+            act.easeDurUnit = DurUnit(base[pos + 1].int)
+            copyMem(addr act.easeDur, addr base[pos + 2], sizeof(float32))
+            pos += 6
+          for which in 0 .. 2:  # x, y, scale keyframe seqs in order
+            let count = base[pos].int
+            pos += 1
+            var s = newSeq[float32](count)
+            for c in 0 ..< count:
+              copyMem(addr s[c], addr base[pos], sizeof(float32))
+              pos += 4
+            case which
+            of 0: act.pxKf = s
+            of 1: act.pyKf = s
+            else: act.pscaleKf = s
+          yield act
+          i = pos
         of actDrawbox:
           var x, y, w, h: int32
           copyMem(addr x, addr base[i + 1], sizeof(int32))
@@ -837,10 +880,22 @@ when not defined(nimscript):
         base.writeAt(i, 7, a.saturation)
         i += 11
       of actPos:
-        base.writeAt(i, 1, a.px)
-        base.writeAt(i, 5, a.py)
-        base.writeAt(i, 9, a.pscale)
-        i += 13
+        if a.hasEase: base[i] = base[i] or easeFlag
+        var pos = i + 1
+        if a.hasEase:
+          base[pos] = uint8(ord(a.easeCurve))
+          base[pos + 1] = uint8(ord(a.easeDurUnit))
+          var d = a.easeDur
+          copyMem(addr base[pos + 2], addr d, sizeof(float32))
+          pos += 6
+        for s in [a.pxKf, a.pyKf, a.pscaleKf]:
+          base[pos] = uint8(s.len)
+          pos += 1
+          for v in s:
+            var vv = v
+            copyMem(addr base[pos], addr vv, sizeof(float32))
+            pos += 4
+        i = pos
       of actDrawbox:
         base.writeAt(i, 1, a.dbX)
         base.writeAt(i, 5, a.dbY)
@@ -904,7 +959,7 @@ when not defined(nimscript):
 
       var action = parseAction(trimmedPart)
       if pendActive and action.kind in {actZoom, actBlur, actOpacity, actBrightness,
-          actVolume} and not action.hasEase:
+          actVolume, actPos} and not action.hasEase:
         action.hasEase = true
         action.easeCurve = pendCurve
         action.easeDurUnit = pendUnit

--- a/src/action.nim
+++ b/src/action.nim
@@ -9,7 +9,8 @@ type
   ActionKind* = enum
     actSpeed, actVarispeed, actVolume, actDeesser, actInvert, actHflip, actVflip,
     actZoom, actOpacity, actBlur, actBrightness, actLuv, actLens, actRotate, actSpin,
-    actDrawbox, actPos, actColorKey, actChromaKey, actLoop, actErosion, actChoke
+    actDrawbox, actPos, actColorKey, actChromaKey, actLoop, actErosion, actChoke,
+    actAberration
 
   Easing* = enum  # interpolation curve for animations
     easeLinear, easeIn, easeOut, easeInOut
@@ -26,6 +27,8 @@ type
     case kind*: ActionKind
     of actInvert, actHflip, actVflip, actLoop, actErosion:
       discard
+    of actChoke:
+      chokeN*: uint8         # matte-erosion passes (px to shrink the alpha matte)
     of actRotate:
       rStart*: Unorm16       # circular [0, 360) static angle (expands the canvas)
     of actSpin:
@@ -56,8 +59,9 @@ type
     of actColorKey, actChromaKey:
       color*: RGBColor
       similar*, blend*: Unorm16
-    of actChoke:
-      chokeN*: uint8         # matte-erosion passes (px to shrink the alpha matte)
+    of actAberration:
+      abRh*, abRv*, abGh*, abGv*, abBh*, abBv*: int8
+      abWrap*: bool          # edge: wrap around (true) vs smear the border (false)
 
   Actions* = distinct int # A fat pointer to a list of action in atf-8 format.
 
@@ -156,6 +160,11 @@ Positional args: `k1` is the quadratic correction factor and `k2` the double-qua
     help: "Make a color transparent by matching it in chroma (YUV) space, tolerating lighting variation, shadows, and soft edges. This is the green-/blue-screen keyer for real camera footage; for flat synthetic backgrounds use `colorkey` instead. On the base (bottom) video track there is nothing to reveal, so the matched color is replaced with the timeline background (`-bg`) instead. Positional args: `color` is the key color (a name like `green` or a hex value), `similar` how close a pixel must be to be keyed (default 0.25), and `blend` how soft the edge is (default 0.0). Implemented via ffmpeg's `chromakey` filter."),
   ActionDef(name: "choke", flags: {afVideo}, argSpec: "[n]", range: rng(1.0, 16.0),
     help: "Shrink (choke) the alpha matte left by a `colorkey`/`chromakey` inward by `n` pixels (default 1), cutting off the ring of key-color spill and ragged edge pixels around the subject. Must come after the key in the chain, e.g. `add:fg.mp4,chromakey:green,choke:2`. Only meaningful on overlay tracks (where keying produces alpha); a no-op on the base track. Implemented by eroding only the alpha plane via ffmpeg's `erosion` filter."),
+  ActionDef(name: "aberration", flags: {afVideo}, argSpec: "[h[:v[:edge]]]", range: rng(-127.0, 127.0, each = true),
+    help: """
+Fake chromatic aberration by shifting the color channels apart, leaving red/cyan fringing for a cheap-lens or glitch look. Implemented via ffmpeg's `rgbashift` filter.
+Simple form `aberration[:h[:v[:edge]]]`: split red and blue symmetrically by `h` pixels horizontally (default 5) and `v` pixels vertically (default 0), with green left in place. `edge` is `smear` (extend the border pixel, the default) or `wrap` (wrap around to the far side).
+Per-channel form: pass `key=value` pairs drawn from `rh`, `rv`, `gh`, `gv`, `bh`, `bv` (signed pixel shift for each channel/axis, default 0) plus `edge`, e.g. `aberration:rh=8:bh=-8:gv=2:edge=wrap`."""),
   ActionDef(name: "loop", flags: {afVideo},
     help: "Loop the clip's source back to its start when it runs out of frames, instead of ending. Useful for overlays whose source (e.g. a short gif) is shorter than the section it covers, e.g. `add:logo.gif,loop`."),
 ]
@@ -384,6 +393,74 @@ func parseAction*(val: string): Action {.raises: [ActionParseError].} =
       raise newException(ActionParseError, "choke must be in [1, 16]")
     return Action(kind: actChoke, chokeN: uint8(n))
 
+  # aberration: per-channel chromatic split. Positional shorthand (no '=') is the
+  # symmetric case `aberration[:h[:v[:edge]]]`; any `key=value` part switches to the
+  # explicit per-channel form, which starts every channel at 0.
+  if parts[0] == "aberration":
+    template chk(n: int): int8 =
+      if n < -127 or n > 127:
+        raise newException(ActionParseError, "aberration shift must be in [-127, 127]")
+      int8(n)
+    proc toEdge(v: string): bool {.raises: [ActionParseError].} =
+      case v
+      of "smear": false
+      of "wrap": true
+      else: raise newException(ActionParseError, "aberration edge must be smear or wrap")
+    var rh, rv, gh, gv, bh, bv = 0
+    var wrap = false
+    var keyword = false
+    for idx in 1 ..< parts.len:
+      if '=' in parts[idx]:
+        keyword = true
+        break
+
+    if parts.len == 1:
+      rh = 5; bh = -5
+    elif not keyword:
+      # Symmetric: up to two bare pixel counts (h, v) plus an optional edge token.
+      var nums: seq[int]
+      for idx in 1 ..< parts.len:
+        let p = parts[idx]
+        if p == "smear" or p == "wrap":
+          wrap = toEdge(p)
+        else:
+          try:
+            nums.add parseInt(p)
+          except ValueError:
+            raise newException(ActionParseError, "Invalid aberration value: " & p)
+      if nums.len > 2:
+        raise newException(ActionParseError, "aberration takes at most h:v positional shifts")
+      let h = (if nums.len >= 1: nums[0] else: 5)
+      let v = (if nums.len >= 2: nums[1] else: 0)
+      rh = h; bh = -h; rv = v; bv = -v
+    else:
+      for idx in 1 ..< parts.len:
+        let p = parts[idx]
+        let eq = p.find('=')
+        if eq < 0:
+          raise newException(ActionParseError, "aberration: expected key=value, got " & p)
+        let key = p[0 ..< eq]
+        let value = p[eq + 1 .. ^1]
+        if key == "edge":
+          wrap = toEdge(value)
+          continue
+        let n = (
+          try:
+            parseInt(value)
+          except ValueError:
+            raise newException(ActionParseError, "Invalid aberration value: " & value)
+        )
+        case key
+        of "rh": rh = n
+        of "rv": rv = n
+        of "gh": gh = n
+        of "gv": gv = n
+        of "bh": bh = n
+        of "bv": bv = n
+        else: raise newException(ActionParseError, "Unknown aberration key: " & key)
+    return Action(kind: actAberration, abRh: chk(rh), abRv: chk(rv),
+      abGh: chk(gh), abGv: chk(gv), abBh: chk(bh), abBv: chk(bv), abWrap: wrap)
+
   # pos: overlay placement "pos:x:y" or "pos:x:y:scale".
   if parts[0] == "pos" and parts.len in {3, 4}:
     try:
@@ -526,17 +603,33 @@ when not defined(nimscript):
     of actColorKey: "colorkey:" & act.color.toString & ":" & $act.similar & ":" & $act.blend
     of actChromaKey: "chromakey:" & act.color.toString & ":" & $act.similar & ":" & $act.blend
     of actChoke: "choke:" & $int(act.chokeN)
+    of actAberration:
+      # A symmetric, green-free, smear split round-trips as the positional shorthand.
+      if not act.abWrap and act.abGh == 0 and act.abGv == 0 and
+          act.abRh >= 0 and act.abBh == -act.abRh and act.abBv == -act.abRv:
+        if act.abRv == 0: "aberration:" & $act.abRh
+        else: "aberration:" & $act.abRh & ":" & $act.abRv
+      else:
+        var ps: seq[string]
+        if act.abRh != 0: ps.add "rh=" & $act.abRh
+        if act.abRv != 0: ps.add "rv=" & $act.abRv
+        if act.abGh != 0: ps.add "gh=" & $act.abGh
+        if act.abGv != 0: ps.add "gv=" & $act.abGv
+        if act.abBh != 0: ps.add "bh=" & $act.abBh
+        if act.abBv != 0: ps.add "bv=" & $act.abBv
+        if act.abWrap: ps.add "edge=wrap"
+        "aberration:" & ps.join(":")
 
   func easeBytes(a: Action): int = (if a.hasEase: 6 else: 0)
 
   func actionByteSize(a: Action): int =
     case a.kind
     of actInvert, actHflip, actVflip, actLoop, actErosion: 1
+    of actChoke: 2
     of actRotate: 3
     of actLens, actSpeed, actVarispeed: 5
     of actDeesser, actSpin: 7
-    of actChoke: 2
-    of actColorKey, actChromaKey: 8
+    of actColorKey, actChromaKey, actAberration: 8
     of actLuv: 11
     of actPos: 13
     of actDrawbox: 20
@@ -607,6 +700,13 @@ when not defined(nimscript):
         of actChoke:
           yield Action(kind: actChoke, chokeN: base[i + 1])
           i += 2
+        of actAberration:
+          yield Action(kind: actAberration,
+            abRh: cast[int8](base[i + 1]), abRv: cast[int8](base[i + 2]),
+            abGh: cast[int8](base[i + 3]), abGv: cast[int8](base[i + 4]),
+            abBh: cast[int8](base[i + 5]), abBv: cast[int8](base[i + 6]),
+            abWrap: base[i + 7] != 0'u8)
+          i += 8
         of actLuv:
           var bh: Snorm16
           var c, s: float32
@@ -722,6 +822,15 @@ when not defined(nimscript):
       of actChoke:
         base[i + 1] = a.chokeN
         i += 2
+      of actAberration:
+        base.writeAt(i, 1, a.abRh)
+        base.writeAt(i, 2, a.abRv)
+        base.writeAt(i, 3, a.abGh)
+        base.writeAt(i, 4, a.abGv)
+        base.writeAt(i, 5, a.abBh)
+        base.writeAt(i, 6, a.abBv)
+        base[i + 7] = (if a.abWrap: 1'u8 else: 0'u8)
+        i += 8
       of actLuv:
         base.writeAt(i, 1, a.brighthue)
         base.writeAt(i, 3, a.contrast)

--- a/src/conductor.nim
+++ b/src/conductor.nim
@@ -195,7 +195,8 @@ proc applyAdds(tl: var v3, args: mainArgs, interner: var StringInterner) =
     # any actions chained after `add:` (which apply to this layer, not the base).
     var acts: seq[Action]
     if spec.hasPos:
-      acts.add Action(kind: actPos, px: spec.x, py: spec.y, pscale: spec.scale)
+      acts.add Action(kind: actPos, pxKf: spec.xKf, pyKf: spec.yKf,
+        pscaleKf: spec.scaleKf)
     if spec.effects.len > 0:
       try:
         for a in parseActions(spec.effects):

--- a/src/ffmpeg.nim
+++ b/src/ffmpeg.nim
@@ -69,6 +69,7 @@ const AV_PIX_FMT_NONE* = AVPixelFormat(-1)
 const AV_PIX_FMT_YUV420P* = AVPixelFormat(0)
 const AV_PIX_FMT_RGB24* = AVPixelFormat(2)
 const AV_PIX_FMT_RGB8* = AVPixelFormat(20)
+const AV_PIX_FMT_RGBA* = AVPixelFormat(26)
 
 type
   AVPixFmtDescriptor* {.importc, incompleteStruct,

--- a/src/log.nim
+++ b/src/log.nim
@@ -51,9 +51,8 @@ type AddSpec* = object
   selector*: int
   setActionRef*: int = -1
   path*: string
-  hasPos*: bool        # whether x/y/scale were given (else origin, native size)
-  x*, y*: int32
-  scale*: float32
+  hasPos*: bool        # whether x:y:scale were given (else origin, native size)
+  xKf*, yKf*, scaleKf*: seq[float32]  # placement ramps (len 1 = static), fed to pos
   effects*: string     # actions chained after `add:` — applied to this overlay
                        # layer (not the base), as a comma-separated atf-8 string
 

--- a/src/main.nim
+++ b/src/main.nim
@@ -262,22 +262,25 @@ proc extractAdds(val: string, selector, setActionRef: int, args: var mainArgs): 
     if f.startsWith("add:"):
       let rest = f[4 .. ^1]
       let segs = rest.split(":")
-      var spec = AddSpec(selector: selector, setActionRef: setActionRef, scale: 1.0'f32)
-      # Need at least one path field plus x:y:scale to be a placement.
+      var spec = AddSpec(selector: selector, setActionRef: setActionRef)
+      # Need at least one path field plus x:y:scale to be a placement. Each of the
+      # three may be a ramp (e.g. 0..600); detected by all parsing as keyframes, so
+      # everything before them is the path (a Windows drive-letter colon stays put).
       var hasPlacement = false
       if segs.len >= 4:
         try:
-          spec.x = int32(parseInt(segs[^3].strip()))
-          spec.y = int32(parseInt(segs[^2].strip()))
-          spec.scale = parseFloat(segs[^1].strip()).float32
+          spec.xKf = parseKeyframes(segs[^3].strip())
+          spec.yKf = parseKeyframes(segs[^2].strip())
+          spec.scaleKf = parseKeyframes(segs[^1].strip())
           hasPlacement = true
-        except ValueError:
+        except ActionParseError:
           hasPlacement = false   # trailing fields aren't numeric => part of path
       if hasPlacement:
         spec.hasPos = true
         spec.path = segs[0 ..< segs.len - 3].join(":")
-        if spec.scale <= 0.0'f32:
-          error "add: scale must be greater than 0.0"
+        for s in spec.scaleKf:
+          if s <= 0.0'f32:
+            error "add: scale must be greater than 0.0"
       else:
         spec.path = rest
       if spec.path.len == 0:

--- a/src/render/video.nim
+++ b/src/render/video.nim
@@ -1,5 +1,5 @@
 import std/[sets, strformat, tables]
-from std/math import round, hypot, ceil
+from std/math import round, hypot, ceil, floor
 
 import ../[action, av, ffmpeg, graph, log, timeline]
 import ../util/[color, dnorm16, rational]
@@ -10,8 +10,8 @@ type VideoFrame = object
   effects: Actions
   local: int  # frame offset within the clip, for animated effects
   dur: int    # clip length in frames
-  x: int32    # overlay placement (canvas pixels); 0 for the base layer
-  y: int32
+  x: float32  # overlay placement (canvas pixels, sub-pixel); 0 for the base layer
+  y: float32
   scale: float32  # overlay size multiplier; 1.0 for the base layer
   fit: bool   # no explicit `pos`: fit-and-center to the canvas like the base
 
@@ -932,37 +932,104 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
   let ovColorspace = (if encoderCtx.colorspace.int in 1 .. 15: encoderCtx.colorspace.int else: 1)
   let ovRange = (if encoderCtx.color_range.int == 2: 2 else: 1)
 
-  proc overlayFrame(base, top: ptr AVFrame; x, y: int; scale: float32): ptr AVFrame =
+  proc subpixelShift(src: ptr AVFrame; dx, dy: float32): ptr AVFrame =
+    ## Bilinearly translate a packed-RGBA frame by (dx, dy) px, sampling
+    ## out-of-bounds as transparent. Lets an animated overlay sit at a fractional
+    ## pixel so a slow position ramp slides smoothly instead of stair-stepping.
+    let w = src.width.int
+    let h = src.height.int
+    let dst = av_frame_alloc()
+    if dst == nil: error "subpixelShift: could not allocate frame"
+    dst.format = src.format
+    dst.width = src.width
+    dst.height = src.height
+    dst.pts = src.pts
+    dst.time_base = src.time_base
+    if av_frame_get_buffer(dst, 32) < 0: error "subpixelShift: bad buffer"
+    let sStride = src.linesize[0].int
+    let dStride = dst.linesize[0].int
+    let sBase = cast[int](src.data[0])
+    let dBase = cast[int](dst.data[0])
+    for y in 0 ..< h:
+      let dRow = cast[ptr UncheckedArray[uint8]](dBase + y * dStride)
+      let syf = y.float32 - dy
+      let y0 = floor(syf).int
+      let wy = syf - y0.float32
+      for x in 0 ..< w:
+        let sxf = x.float32 - dx
+        let x0 = floor(sxf).int
+        let wx = sxf - x0.float32
+        for c in 0 ..< 4:  # bilinear blend of the 4 neighbours, per RGBA channel
+          template px(xx, yy: int): float32 =
+            if xx < 0 or xx >= w or yy < 0 or yy >= h: 0.0'f32
+            else: cast[ptr UncheckedArray[uint8]](sBase + yy * sStride)[xx * 4 + c].float32
+          let t = px(x0, y0) * (1 - wx) + px(x0 + 1, y0) * wx
+          let b = px(x0, y0 + 1) * (1 - wx) + px(x0 + 1, y0 + 1) * wx
+          dRow[x * 4 + c] = uint8(clamp(t * (1 - wy) + b * wy + 0.5'f32, 0, 255))
+    return dst
+
+  proc overlayFrame(base, top: ptr AVFrame; x, y: float32; scale: float32): ptr AVFrame =
     ## Composite `top` over `base` at (x, y), preserving the overlay's alpha.
-    ## Built per call because `overlay` is a framesync filter (needs EOF on both
-    ## inputs to emit).
+    ## (x, y) may be fractional: `overlay` places the integer part (it only does
+    ## whole pixels) and a bilinear shift places the sub-pixel remainder, so a slow
+    ## animated position slides smoothly. Built per call because `overlay` is a
+    ## framesync filter (needs EOF on both inputs to emit).
+    let ix = floor(x).int
+    let iy = floor(y).int
+    let fx = x - ix.float32
+    let fy = y - iy.float32
+    let nw = max(2, int(top.width.float32 * scale))
+    let nh = max(2, int(top.height.float32 * scale))
     base.colorspace = cint(ovColorspace)
     base.color_range = cint(ovRange)
     base.pts = 0
-    top.pts = 0
     let baseArgs = bufArgsOf(base) & &":colorspace={ovColorspace}:range={ovRange}"
-    let topArgs = bufArgsOf(top)
-    let nw = max(2, int(top.width.float32 * scale))
-    let nh = max(2, int(top.height.float32 * scale))
+    # The two buffer sources must be nodes 0 (base) and 1 (top) and the sink last,
+    # to match pushIdx(0/1) and pull's nodes[^1].
     let g = newGraph()
     let b0 = g.add("buffer", baseArgs)
-    let b1 = g.add("buffer", topArgs)
-    let topRgba = g.add("format", "pix_fmts=rgba")
-    let scl = g.add("scale", &"{nw}:{nh}:flags=bicubic")
-    let ov = g.add("overlay", &"x={x}:y={y}:format=yuv420")
-    let sink = g.add("buffersink")
-    g.link(b1, topRgba, 0, 0)
-    g.link(topRgba, scl, 0, 0)
-    g.link(b0, ov, 0, 0)
-    g.link(scl, ov, 0, 1)
-    g.link(ov, sink, 0, 0)
-    g.configure()
-    g.pushIdx(0, base)
-    g.pushIdx(1, top)
-    g.flushIdx(0)
-    g.flushIdx(1)
-    result = g.pull()
-    g.cleanup()
+
+    if abs(fx) < 0.001'f32 and abs(fy) < 0.001'f32:
+      # Whole-pixel placement: scale in-graph (bicubic) and overlay, as before.
+      top.pts = 0
+      let b1 = g.add("buffer", bufArgsOf(top))
+      let topRgba = g.add("format", "pix_fmts=rgba")
+      let scl = g.add("scale", &"{nw}:{nh}:flags=bicubic")
+      let ov = g.add("overlay", &"x={ix}:y={iy}:format=yuv420")
+      let sink = g.add("buffersink")
+      g.link(b1, topRgba, 0, 0)
+      g.link(topRgba, scl, 0, 0)
+      g.link(b0, ov, 0, 0)
+      g.link(scl, ov, 0, 1)
+      g.link(ov, sink, 0, 0)
+      g.configure()
+      g.pushIdx(0, base)
+      g.pushIdx(1, top)
+      g.flushIdx(0)
+      g.flushIdx(1)
+      result = g.pull()
+      g.cleanup()
+    else:
+      # Sub-pixel placement: scale to rgba up front (so alpha survives), nudge it by
+      # the fractional remainder, then overlay the prepared frame at the whole pixel.
+      let scaled = top.reformat(AV_PIX_FMT_RGBA, nw.cint, nh.cint)
+      let shifted = subpixelShift(scaled, fx, fy)
+      shifted.pts = 0
+      let b1 = g.add("buffer", bufArgsOf(shifted))
+      let ov = g.add("overlay", &"x={ix}:y={iy}:format=yuv420")
+      let sink = g.add("buffersink")
+      g.link(b0, ov, 0, 0)
+      g.link(b1, ov, 0, 1)
+      g.link(ov, sink, 0, 0)
+      g.configure()
+      g.pushIdx(0, base)
+      g.pushIdx(1, shifted)
+      g.flushIdx(0)
+      g.flushIdx(1)
+      result = g.pull()
+      g.cleanup()
+      av_frame_free(addr shifted)
+      if scaled != top: av_frame_free(addr scaled)
 
   proc finalizeFrame(f: ptr AVFrame; index: int64): ptr AVFrame =
     var frame = f
@@ -1000,7 +1067,7 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
             var speed = 1.0
             # Overlay placement comes from a `pos` action in the clip's effects
             # (keeps Clip itself position-free); defaults to the canvas origin.
-            var ox, oy = 0'i32
+            var ox, oy = 0.0'f32
             var oscale = 1.0'f32
             var hasPos = false
             for effect in effectGroup:
@@ -1008,9 +1075,14 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
                 speed *= effect.val
               elif effect.kind == actPos:
                 hasPos = true
-                ox = effect.px
-                oy = effect.py
-                oscale = effect.pscale
+                # Sample the placement ramps at this frame's progress, eased like
+                # the other animatable effects; static pos has 1-keyframe seqs.
+                # Kept as floats so overlayFrame can place at a sub-pixel offset.
+                let pp = applyEase(effect.easeCurve, clipT(int(index - obj.start),
+                  envAnimLen(effect.easeDurUnit, effect.easeDur, int(obj.dur), tl.tb.float)))
+                ox = sampleKf(effect.pxKf, pp)
+                oy = sampleKf(effect.pyKf, pp)
+                oscale = sampleKf(effect.pscaleKf, pp)
 
             # A synthesized background base (nil src) has no source frame.
             let sourceFramePos =
@@ -1050,14 +1122,14 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
           # No explicit `pos`: fit the overlay to the canvas and center it, like
           # the base layer (scaleWithPad), but let the padding stay transparent
           # so only the image shows over the base.
-          var ox = o.x.int
-          var oy = o.y.int
+          var ox = o.x
+          var oy = o.y
           var oscale = o.scale
           if o.fit:
             oscale = min(acc.width.float32 / top.width.float32,
                          acc.height.float32 / top.height.float32)
-            ox = (acc.width - int(top.width.float32 * oscale)) div 2
-            oy = (acc.height - int(top.height.float32 * oscale)) div 2
+            ox = float32((acc.width - int(top.width.float32 * oscale)) div 2)
+            oy = float32((acc.height - int(top.height.float32 * oscale)) div 2)
           let newAcc = overlayFrame(acc, top, ox, oy, oscale)
           av_frame_free(addr acc)
           av_frame_free(addr top)

--- a/src/render/video.nim
+++ b/src/render/video.nim
@@ -756,6 +756,24 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
           nodes.add fxGraph.add("format", &"pix_fmts={$AVPixelFormat(frame.format)}")
           nodes.add fxGraph.add("buffersink")
           fxGraph.linkNodes(nodes).configure()
+      of actAberration:
+        # Fake chromatic aberration: slide each color channel by its own offset,
+        # so the gaps show up as colored fringing. Via rgba so an overlay layer's
+        # alpha rides through unshifted.
+        let edge = (if effect.abWrap: "wrap" else: "smear")
+        runFx(fxId(actAberration, frame,
+            i0 = effect.abRh.int32, i1 = effect.abRv.int32,
+            i2 = effect.abGh.int32, i3 = effect.abGv.int32,
+            f0 = effect.abBh.float32, f1 = effect.abBv.float32,
+            col = (if effect.abWrap: 1'u32 else: 0'u32))):
+          let bufferSrc = fxGraph.add("buffer", bufArgsOf(frame))
+          let toRgba = fxGraph.add("format", "pix_fmts=rgba")
+          let shift = fxGraph.add("rgbashift",
+            &"rh={effect.abRh}:rv={effect.abRv}:gh={effect.abGh}:gv={effect.abGv}" &
+            &":bh={effect.abBh}:bv={effect.abBv}:edge={edge}")
+          let toOrig = fxGraph.add("format", &"pix_fmts={$AVPixelFormat(frame.format)}")
+          let bufferSink = fxGraph.add("buffersink")
+          fxGraph.linkNodes(@[bufferSrc, toRgba, shift, toOrig, bufferSink]).configure()
     return frame
 
   proc decodeClipFrame(obj: VideoFrame): (ptr AVFrame, bool) =


### PR DESCRIPTION
Aberration splits the RGB channels apart via FFmpeg's rgbashift for a cheap-lens/glitch fringe. Two forms: the positional shorthand aberration[:h[:v[:edge]]] (symmetric red/blue split) and key=value pairs (rh rv gh gv bh bv edge) for full per-channel control.