### PR TITLE
Add templateFile field to v3 timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
  - URL inputs edited with only `subtitle`/`word`/`regex` no longer download the full video; these methods read the subtitle stream, so just audio is fetched.
  - `add:` overlays now follow the base layer's cuts by default, staying time-synced like a second camera angle, instead of restarting from frame 0 each kept section. Pass `follow-base=0` (e.g. `add:logo.gif:follow-base=0`) to restore the restart-per-section behavior for logos/gifs.
  - The render now copies the source's display-matrix rotation onto the output, so phone-shot portrait videos (stored landscape with a rotate flag) no longer play sideways.
+ - The v3 timeline format gained a `templateFile` field (the first input), used as the source for stream rotation and attachment passthrough.

--- a/src/exports/json.nim
+++ b/src/exports/json.nim
@@ -61,6 +61,7 @@ func `%`*(self: v3): JsonNode =
 
   return %* {
     "version": "3",
+    "templateFile": (if self.templateFile != nil: self.templateFile[] else: ""),
     "timebase": $self.tb.num & "/" & $self.tb.den,
     "background": self.bg.toString,
     "resolution": [self.res[0], self.res[1]],

--- a/src/imports/fcp7.nim
+++ b/src/imports/fcp7.nim
@@ -205,6 +205,7 @@ proc fcp7ReadXml*(path: string, interner: var StringInterner): v3 =
 
   let bg = RGBColor(red: 0, green: 0, blue: 0)
   result = v3(tb: tb, bg: bg, sr: sr, res: res, v: vobjs, a: aobjs, effects: effects)
+  result.templateFile = result.firstSource
   result.layout = initLayout("stereo")
   while result.langs.len < result.v.len + result.a.len:
     result.langs.add ['u', 'n', 'd', '\0']

--- a/src/imports/json.nim
+++ b/src/imports/json.nim
@@ -95,6 +95,9 @@ proc parseV3*(jsonNode: JsonNode, interner: var StringInterner): v3 =
   while result.langs.len < result.v.len + result.a.len:
     result.langs.add ['u', 'n', 'd', '\0']
 
+  let tf = jsonNode{"templateFile"}.getStr("")
+  result.templateFile = if tf != "": interner.intern(tf) else: result.firstSource
+
 
 proc parseV2*(jsonNode: JsonNode, interner: var StringInterner): v3 =
   let input = jsonNode["source"].getStr()

--- a/src/render/format.nim
+++ b/src/render/format.nim
@@ -258,57 +258,45 @@ proc makeMedia*(args: mainArgs, tl: var v3, outputPath: string, rules: Rules, ba
     error "Could not allocate output packet"
   defer: av_packet_free(addr outPacket)
 
-  if not args.dn:
-    # Get the first source pointer from the timeline so we can hit the cache.
-    var sourceSrc: ptr string = nil
-    block findSource:
-      for vlayer in tl.v:
-        if vlayer.len > 0:
-          sourceSrc = vlayer[0].src
-          break findSource
-      for alayer in tl.a:
-        if alayer.len > 0:
-          sourceSrc = alayer[0].src
-          break findSource
+  # Attachments (fonts, cover art) are copied from the template file.
+  if not args.dn and tl.templateFile != nil:
+    if cache != nil:
+      imageSourceCtx = cache.getContainer(tl.templateFile).formatContext
+    else:
+      imageSourceCtx = av.openFormatCtx(tl.templateFile[].cstring)
+      ownsImageSourceCtx = true
 
-    if sourceSrc != nil:
-      if cache != nil:
-        imageSourceCtx = cache.getContainer(sourceSrc).formatContext
-      else:
-        imageSourceCtx = av.openFormatCtx(sourceSrc[].cstring)
-        ownsImageSourceCtx = true
-
-      for i in 0 ..< imageSourceCtx.nb_streams:
-        let strm = imageSourceCtx.streams[i]
-        if strm.codecpar.codec_type == AVMEDIA_TYPE_ATTACHMENT:
-          let outStrm = avformat_new_stream(output.formatCtx, nil)
-          if outStrm == nil:
-            error "Could not allocate attachment stream"
-          if avcodec_parameters_copy(outStrm.codecpar, strm.codecpar) < 0:
-            error "Could not copy attachment codec parameters"
-          if strm.metadata != nil:
-            discard av_dict_copy(addr outStrm.metadata, strm.metadata, 0)
-        elif strm.codecpar.codec_type == AVMEDIA_TYPE_VIDEO and
-            (strm.disposition and AV_DISPOSITION_ATTACHED_PIC) != 0:
-          if avformat_query_codec(output.formatCtx.oformat, strm.codecpar.codec_id,
-              FF_COMPLIANCE_EXPERIMENTAL) == 0:
-            continue
-          let outStrm = avformat_new_stream(output.formatCtx, nil)
-          if outStrm == nil:
-            error "Could not allocate image stream"
-          if avcodec_parameters_copy(outStrm.codecpar, strm.codecpar) < 0:
-            error "Could not copy image codec parameters"
-          if outStrm.codecpar.width == 0 or outStrm.codecpar.height == 0:
-            if strm.codecpar.codec_id == ID_PNG:
-              let (w, h) = pngDimensions(strm.attached_pic.data, strm.attached_pic.size)
-              if w > 0 and h > 0:
-                outStrm.codecpar.width = w
-                outStrm.codecpar.height = h
-          outStrm.time_base = strm.time_base
-          outStrm.disposition = strm.disposition
-          if strm.metadata != nil:
-            discard av_dict_copy(addr outStrm.metadata, strm.metadata, 0)
-          imageStreams.add((outStrm, addr strm.attached_pic))
+    for i in 0 ..< imageSourceCtx.nb_streams:
+      let strm = imageSourceCtx.streams[i]
+      if strm.codecpar.codec_type == AVMEDIA_TYPE_ATTACHMENT:
+        let outStrm = avformat_new_stream(output.formatCtx, nil)
+        if outStrm == nil:
+          error "Could not allocate attachment stream"
+        if avcodec_parameters_copy(outStrm.codecpar, strm.codecpar) < 0:
+          error "Could not copy attachment codec parameters"
+        if strm.metadata != nil:
+          discard av_dict_copy(addr outStrm.metadata, strm.metadata, 0)
+      elif strm.codecpar.codec_type == AVMEDIA_TYPE_VIDEO and
+          (strm.disposition and AV_DISPOSITION_ATTACHED_PIC) != 0:
+        if avformat_query_codec(output.formatCtx.oformat, strm.codecpar.codec_id,
+            FF_COMPLIANCE_EXPERIMENTAL) == 0:
+          continue
+        let outStrm = avformat_new_stream(output.formatCtx, nil)
+        if outStrm == nil:
+          error "Could not allocate image stream"
+        if avcodec_parameters_copy(outStrm.codecpar, strm.codecpar) < 0:
+          error "Could not copy image codec parameters"
+        if outStrm.codecpar.width == 0 or outStrm.codecpar.height == 0:
+          if strm.codecpar.codec_id == ID_PNG:
+            let (w, h) = pngDimensions(strm.attached_pic.data, strm.attached_pic.size)
+            if w > 0 and h > 0:
+              outStrm.codecpar.width = w
+              outStrm.codecpar.height = h
+        outStrm.time_base = strm.time_base
+        outStrm.disposition = strm.disposition
+        if strm.metadata != nil:
+          discard av_dict_copy(addr outStrm.metadata, strm.metadata, 0)
+        imageStreams.add((outStrm, addr strm.attached_pic))
 
   output.startEncoding()
 

--- a/src/render/video.nim
+++ b/src/render/video.nim
@@ -460,9 +460,10 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
   if avcodec_parameters_from_context(outputStream.codecpar, encoderCtx) < 0:
     error "Could not copy encoder parameters to stream"
 
-  let baseVid = myCache.cns[tl.v[0][0].src].video
-  if baseVid.len > 0:
-    let srcPar = baseVid[0].codecpar
+  let templateVid = if tl.templateFile != nil:
+    myCache.getContainer(tl.templateFile).video else: @[]
+  if templateVid.len > 0:
+    let srcPar = templateVid[0].codecpar
     let sd = av_packet_side_data_get(srcPar.coded_side_data,
         srcPar.nb_coded_side_data, AV_PKT_DATA_DISPLAYMATRIX)
     if sd != nil and sd.size > 0:

--- a/src/timeline.nim
+++ b/src/timeline.nim
@@ -39,6 +39,7 @@ type v3* = object
   langs*: seq[Lang]   # Video, Audio (flattened).
   effects*: seq[Actions]
   clips2*: seq[Clip2] # Empty when the timeline is non-linear.
+  templateFile*: ptr string
 
 func len*(self: v3): int64 =
   result = 0
@@ -49,9 +50,16 @@ func len*(self: v3): int64 =
     if len(clips) > 0:
       result = max(result, clips[^1].start + clips[^1].dur)
 
+func firstSource*(self: v3): ptr string =
+  for vlayer in self.v:
+    if vlayer.len > 0 and vlayer[0].src != nil:
+      return vlayer[0].src
+  for alayer in self.a:
+    if alayer.len > 0 and alayer[0].src != nil:
+      return alayer[0].src
+  return nil
+
 func uniqueSources*(self: v3): HashSet[ptr string] =
-  # A nil src is a synthesized background clip (audio-only `add`); it has no
-  # file to open, so it never belongs in the source set.
   for vlayer in self.v:
     for video in vlayer:
       if video.src != nil:
@@ -166,7 +174,8 @@ proc initLinearTimeline*(src: ptr string, tb: AVRational, bg: RGBColor, mi: Medi
       start += dur
       i += 1
 
-  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes())
+  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes(),
+    templateFile: src)
   mutHelper(result, mi, clips)
 
 proc appendLinearTimeline*(tl: var v3, src: ptr string, mi: MediaInfo, actionIndex: seq[int]) =
@@ -269,7 +278,8 @@ proc toNonLinear*(src: ptr string, tb: AVRational, bg: RGBColor, mi: MediaInfo,
       start += dur
       i += 1
 
-  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes())
+  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes(),
+    templateFile: src)
   mutHelper(result, mi, clips)
 
 proc toNonLinear2*(src: ptr string, tb: AVRational, bg: RGBColor, mi: MediaInfo,
@@ -296,7 +306,8 @@ proc toNonLinear2*(src: ptr string, tb: AVRational, bg: RGBColor, mi: MediaInfo,
 
     start += dur
 
-  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes())
+  result = v3(tb: tb, bg: bg, effects: effects, clips2: clips2, res: mi.getRes(),
+    templateFile: src)
   mutHelper(result, mi, clips)
 
 proc applyArgs*(tl: var v3, args: mainArgs) =


### PR DESCRIPTION
The first input is the timeline's template: source of truth for adding video stream rotation and attachments. Replaces the ad-hoc first-source scans in render. Parsed v3 JSON without the field falls back to firstSource for backwards compat.