### PR TITLE
Improve Premiere overlay export (FCP7 XML + OTIO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,6 @@
  - `add:` overlays now follow the base layer's cuts by default, staying time-synced like a second camera angle, instead of restarting from frame 0 each kept section. Pass `follow-base=0` (e.g. `add:logo.gif:follow-base=0`) to restore the restart-per-section behavior for logos/gifs.
  - The render now copies the source's display-matrix rotation onto the output, so phone-shot portrait videos (stored landscape with a rotate flag) no longer play sideways.
  - The v3 timeline format gained a `templateFile` field (the first input), used as the source for stream rotation and attachment passthrough.
+ - The Premiere (FCP7 XML) export now writes `add:` overlays as their own video tracks instead of dropping every track above the base. File defs report the source's real frame size, and still images get a finite duration so Premiere holds them correctly.
+ - The Premiere OTIO export now maps an overlay's `pos:x:y:scale` to Premiere's Motion effect, and gives each overlay a unique link ID so Premiere no longer fuses overlays with the audio.
+ - Exporting an audio-only input with `add:` overlays to Premiere no longer crashes; the synthesized background canvas is skipped in both exports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
  - Remove deprecated value `all/e` for `--edit`, use `all` or `0`.
 
 ## Features
- - Add the `duck` audio action (autoduck/sidechain), which lowers a clip's audio wherever the louder audio layers beneath it (higher track indices) are active — e.g. tuck a music/desktop track under a voice track. Applied when audio layers are mixed; a no-op on the bottom-most layer and on single-layer audio. Tunable as `duck[:amount[:threshold[:attack[:release]]]]` (defaults `0.85:0.04:100:500`, times in ms).
- - Add the `erosion` action (3x3 local-minimum filter, a gritty eaten-away look) and the `choke:[n]` action, which shrinks the alpha matte left by `colorkey`/`chromakey` inward by `n` pixels to cut off key-color spill fringe on overlay tracks.
  - Add the `blackdetect` edit method, which marks frames as loud when at least `threshold` of their pixels are black. Wrap in `(not ...)` to cut black fades/dead air.
- - Add the `aberration` action, which fakes chromatic aberration by shifting the color channels apart for a cheap-lens/glitch color-fringing look. Use the shorthand `aberration[:h[:v[:edge]]]` for a symmetric red/blue split (horizontal `h`, vertical `v`, `edge` of `smear`/`wrap`), or `key=value` pairs (`rh rv gh gv bh bv edge`) for full per-channel control, e.g. `aberration:rh=8:bh=-8:gv=2:edge=wrap`.
- - The `pos` action is now animatable: each of `x`, `y`, and `scale` takes a keyframe ramp (`pos:0..600:300:1..0.5`) with optional easing, so an overlay can slide and resize across a section. The `add:path:x:y:scale` placement fields accept the same ramps (`add:logo.png:0..1000:300:1..0.5`). Overlays are placed at sub-pixel positions, so slow motion slides smoothly instead of stair-stepping.
- - Re-enable the `qtrle` (QuickTime Animation) decoder, so legacy alpha-channel overlay `.mov` files composite onto a base track instead of failing with "Decoder not found".
+ - Add the `duck` audio action (autoduck/sidechain), which lowers a clip's audio wherever the louder audio layers beneath it (higher track indices) are active — e.g. tuck a music/desktop track under a voice track. Applied when audio layers are mixed; a no-op on the bottom-most layer and on single-layer audio.
+ - Add the `erosion` action (3x3 local-minimum filter, a gritty eaten-away look) and the `choke:[n]` action, which shrinks the alpha matte left by `colorkey`/`chromakey` inward by `n` pixels to cut off key-color spill fringe on overlay tracks.
+ - Add the `aberration` action, which fakes chromatic aberration by shifting the color channels apart for a cheap-lens/glitch color-fringing look.
+ - The `pos` action is now animatable: each of `x`, `y`, and `scale` takes a keyframe ramp (`pos:0..600:300:1..0.5`) with optional easing, so an overlay can slide and resize across a section. The `add:path:x:y:scale` placement fields accept the same ramps (`add:logo.png:0..1000:300:1..0.5`).
+ - `premiere` export (fcp7) can now handle overlays.
+ - `premiere-otio` export can now handle overlays, more actions, and animations.
+
 
 ## Performance
  - 
@@ -17,11 +19,8 @@
 ## Fixes
  - The `regex`, `subtitle`, and `word` edit methods now advance positional arguments, so `stream` and `ignore-case` work when passed by position (e.g. `(word "hi" 0 #f)`), not only as keywords.
  - The `levels` command now accepts the `ignore-case` parameter for the `word`/`regex`/`subtitle` methods and honors case-folding (`word` is case-insensitive by default), matching `--edit`.
- - The Edit Reference page is now generated from the source, so it documents `word`, `regex`, `xor`, and `not` (previously omitted), corrects `motion`'s argument order, and drops the unimplemented `max-count`.
  - URL inputs edited with only `subtitle`/`word`/`regex` no longer download the full video; these methods read the subtitle stream, so just audio is fetched.
  - `add:` overlays now follow the base layer's cuts by default, staying time-synced like a second camera angle, instead of restarting from frame 0 each kept section. Pass `follow-base=0` (e.g. `add:logo.gif:follow-base=0`) to restore the restart-per-section behavior for logos/gifs.
  - The render now copies the source's display-matrix rotation onto the output, so phone-shot portrait videos (stored landscape with a rotate flag) no longer play sideways.
  - The v3 timeline format gained a `templateFile` field (the first input), used as the source for stream rotation and attachment passthrough.
- - The Premiere (FCP7 XML) export now writes `add:` overlays as their own video tracks instead of dropping every track above the base. File defs report the source's real frame size, and still images get a finite duration so Premiere holds them correctly.
- - The Premiere OTIO export now maps an overlay's `pos:x:y:scale` to Premiere's Motion effect, and gives each overlay a unique link ID so Premiere no longer fuses overlays with the audio.
- - Exporting an audio-only input with `add:` overlays to Premiere no longer crashes; the synthesized background canvas is skipped in both exports.
+ - Re-enable the `qtrle` (QuickTime Animation) decoder, so legacy alpha-channel overlay `.mov` files composite onto a base track instead of failing with "Decoder not found".

--- a/ae.nimble
+++ b/ae.nimble
@@ -801,7 +801,7 @@ func basicPcms(): seq[string] =
       result.add &"pcm_{t}{size}le"
 
 proc setupCommonFlags(packages: seq[Package], kind: CrossKind = native): string =
-  var enableEncoders: seq[string] = "aac,aac_fixed,ac3,ac3_fixed,alac,ass,cfhd,dvbsub,dvdsub,dvvideo,ffv1,flac,gif,h263,h263p,hdr,libmp3lame,libopus,libx264,libx264rgb,movtext,mp2,mp2fixed,mpeg1video,mpeg2video,mpeg4,prores,prores_aw,prores_ks,srt,ssa,text,vorbis,webvtt".split(",")
+  var enableEncoders: seq[string] = "aac,aac_fixed,ac3,ac3_fixed,alac,ass,cfhd,dvbsub,dvdsub,dvvideo,ffv1,flac,gif,h263,h263p,hdr,libmp3lame,libopus,libx264,libx264rgb,movtext,mp2,mp2fixed,mpeg1video,mpeg2video,mpeg4,png,prores,prores_aw,prores_ks,srt,ssa,text,vorbis,webvtt".split(",")
 
   enableEncoders &= basicPcms()
   enableEncoders &= "pcm_bluray,pcm_s32le_planar,pcm_s24le_planar,pcm_s16be_planar,pcm_s16le_planar,pcm_s8_planar".split(",")

--- a/src/exports/fcp7.nim
+++ b/src/exports/fcp7.nim
@@ -1,5 +1,5 @@
 import std/[os, sets, strformat, tables, xmltree]
-from std/math import ceil
+from std/math import ceil, round
 when defined(windows):
   import std/strutils
 
@@ -63,7 +63,7 @@ func speedup(speed: float): XmlNode =
 
 
 proc mediaDef(filedef: XmlNode, url: string, mi: MediaInfo, tl: v3, tb: int64,
-    ntsc: string) =
+    ntsc: string, durationStr: string) =
   filedef.add elem("name", agSplitFile(mi.path).name)
   filedef.add elem("pathurl", url)
 
@@ -81,8 +81,10 @@ proc mediaDef(filedef: XmlNode, url: string, mi: MediaInfo, tl: v3, tb: int64,
   rate2.add elem("ntsc", ntsc)
   filedef.add rate2
 
-  # DaVinci Resolve needs this tag even though it's blank
-  filedef.add elem("duration", "")
+  # Blank for Resolve (which needs the tag present but empty) and for real video
+  # (Premiere reads the length from the media); a frame count for still images so
+  # Premiere holds them instead of falling back to its huge default still length.
+  filedef.add elem("duration", durationStr)
 
   let mediadef = newElement("media")
 
@@ -93,8 +95,10 @@ proc mediaDef(filedef: XmlNode, url: string, mi: MediaInfo, tl: v3, tb: int64,
     rate3.add elem("timebase", $tb)
     rate3.add elem("ntsc", ntsc)
     vschar.add rate3
-    vschar.add elem("width", $tl.res[0])
-    vschar.add elem("height", $tl.res[1])
+    # The file def must describe the source's own frame size, not the sequence's;
+    # an overlay still/clip is often a different size than the timeline.
+    vschar.add elem("width", $mi.v[0].width)
+    vschar.add elem("height", $mi.v[0].height)
     vschar.add elem("pixelaspectratio", "square")
     videodef.add vschar
     mediadef.add videodef
@@ -264,6 +268,12 @@ proc handlePath(src: string): string =
   else:
     absPath
 
+func isStillImage(mi: MediaInfo, tb: AVRational): bool =
+  ## A source with a video stream but essentially no duration (0 or 1 frame) is a
+  ## still image. Premiere holds these for a fixed length; given a blank
+  ## `<duration>` it ignores the clip's in/out and falls back to a ~12h default.
+  mi.v.len > 0 and int64(round(mi.duration * tb.float64)) <= 1
+
 proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
   let (width, height) = tl.res
   let (timebase, ntsc) = setTbNtsc(tl.tb)
@@ -286,12 +296,25 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
     let pathurl = miToUrl[mi]
     let filedef = <>file(id = miToId[mi])
     if pathurl notin fileDefs:
-      mediaDef(filedef, pathurl, mi, tl, timebase, ntsc)
+      let durationStr =
+        if resolve: ""                              # Resolve wants it blank
+        elif isStillImage(mi, tl.tb): $tl.len       # hold the still long enough
+        else: ""                                    # Premiere reads media length
+      mediaDef(filedef, pathurl, mi, tl, timebase, ntsc, durationStr)
       fileDefs.incl(pathurl)
     clipitem.add filedef
 
   let hasVideo = tl.v.len > 0 and tl.v[0].len > 0
-  let firstAudioId = (if hasVideo: tl.v[0].len + 1 else: 1)
+
+  # clipitem ids run V1, V2, ... then audio. Overlay tracks (v[1..]) used to be
+  # dropped entirely; emitting them means audio ids must start past every video
+  # clip, not just v[0]'s.
+  var videoTrackStart = newSeq[int](tl.v.len)
+  var nextVideoId = 1
+  for k in 0 ..< tl.v.len:
+    videoTrackStart[k] = nextVideoId
+    nextVideoId += tl.v[k].len
+  let firstAudioId = (if hasVideo: nextVideoId else: 1)
   let audioPlan = (if resolve: @[]
                    else: planPremiereAudio(tl, ptrToMi, firstAudioId))
 
@@ -322,59 +345,80 @@ proc fcp7WriteXml*(name, output: string, resolve: bool, tl: v3) =
   video.add vformat
 
   if hasVideo:
-    let track = newElement("track")
+    for vIdx, vlayer in tl.v:
+      # resolve-fcp7's link/id scheme is wired for a single video track; only
+      # Premiere gets the overlay tracks (v[1..]).
+      if resolve and vIdx > 0:
+        break
+      if vlayer.len == 0:
+        continue
+      let track = newElement("track")
+      let trackStart = videoTrackStart[vIdx]
 
-    for j, clip in tl.v[0].pairs:
-      let startVal = $clip.start
-      let endVal = $(clip.start + clip.dur)
-      let inVal = $clip.offset
-      let outVal = $(clip.offset + clip.dur)
+      for j, clip in vlayer.pairs:
+        # An audio-only timeline that gained `add:` overlays has a synthesized
+        # base track with no source file (just a render canvas); there is nothing
+        # to write for Premiere, so skip it (and drop a track left empty).
+        if clip.src == nil:
+          continue
 
-      let thisClipid = &"clipitem-{j + 1}"
-      let clipitem = <>clipitem(id = thisClipid)
-      clipitem.add elem("name", agSplitFile(clip.src[]).name)
-      clipitem.add elem("enabled", "TRUE")
-      clipitem.add elem("start", startVal)
-      clipitem.add elem("end", endVal)
-      clipitem.add elem("in", inVal)
-      clipitem.add elem("out", outVal)
+        let mi = ptrToMi[clip.src]
+        let still = isStillImage(mi, tl.tb)
+        let startVal = $clip.start
+        let endVal = $(clip.start + clip.dur)
+        # A still is the same frame at every offset, so read `dur` frames from 0;
+        # real media keeps its true source in/out.
+        let inVal = (if still: "0" else: $clip.offset)
+        let outVal = (if still: $clip.dur else: $(clip.offset + clip.dur))
 
-      let mi = ptrToMi[clip.src]
-      makeFiledef(clipitem, mi)
+        let thisClipid = &"clipitem-{trackStart + j}"
+        let clipitem = <>clipitem(id = thisClipid)
+        clipitem.add elem("name", agSplitFile(clip.src[]).name)
+        clipitem.add elem("enabled", "TRUE")
+        clipitem.add elem("start", startVal)
+        clipitem.add elem("end", endVal)
+        clipitem.add elem("in", inVal)
+        clipitem.add elem("out", outVal)
 
-      clipitem.add elem("compositemode", "normal")
+        makeFiledef(clipitem, mi)
 
-      let effectGroup = tl.effects[clip.effects]
-      for effect in effectGroup:
-        if effect.kind in [actSpeed, actVarispeed]:
-          clipitem.add speedup(effect.val * 100)
-          break
+        clipitem.add elem("compositemode", "normal")
 
-      if resolve:
-        let link1 = newElement("link")
-        link1.add elem("linkclipref", thisClipid)
-        clipitem.add link1
-        let link2 = newElement("link")
-        link2.add elem("linkclipref", &"clipitem-{tl.v[0].len + j + 1}")
-        clipitem.add link2
-      else:
-        let vlink = newElement("link")
-        vlink.add elem("linkclipref", thisClipid)
-        vlink.add elem("mediatype", "video")
-        vlink.add elem("trackindex", "1")
-        vlink.add elem("clipindex", $(j + 1))
-        clipitem.add vlink
-        for k, atrack in audioPlan:
-          if j >= tl.a[atrack.layerIdx].len: continue
-          let link = newElement("link")
-          link.add elem("linkclipref", &"clipitem-{atrack.firstClipId + j}")
-          link.add elem("mediatype", "audio")
-          link.add elem("trackindex", $(k + 1))
-          link.add elem("clipindex", $(j + 1))
-          clipitem.add link
+        let effectGroup = tl.effects[clip.effects]
+        for effect in effectGroup:
+          if effect.kind in [actSpeed, actVarispeed]:
+            clipitem.add speedup(effect.val * 100)
+            break
 
-      track.add clipitem
-    video.add track
+        if resolve:
+          let link1 = newElement("link")
+          link1.add elem("linkclipref", thisClipid)
+          clipitem.add link1
+          let link2 = newElement("link")
+          link2.add elem("linkclipref", &"clipitem-{tl.v[0].len + j + 1}")
+          clipitem.add link2
+        elif vIdx == 0:
+          # Base track: link the clip to itself and to its aligned audio clips so
+          # they move together. Overlay tracks (v[1..]) carry no audio, so they
+          # stay standalone rather than forming a one-member self-link group.
+          let vlink = newElement("link")
+          vlink.add elem("linkclipref", thisClipid)
+          vlink.add elem("mediatype", "video")
+          vlink.add elem("trackindex", "1")
+          vlink.add elem("clipindex", $(j + 1))
+          clipitem.add vlink
+          for k, atrack in audioPlan:
+            if j >= tl.a[atrack.layerIdx].len: continue
+            let link = newElement("link")
+            link.add elem("linkclipref", &"clipitem-{atrack.firstClipId + j}")
+            link.add elem("mediatype", "audio")
+            link.add elem("trackindex", $(k + 1))
+            link.add elem("clipindex", $(j + 1))
+            clipitem.add link
+
+        track.add clipitem
+      if track.len > 0:
+        video.add track
 
   media.add video
 

--- a/src/exports/otio.nim
+++ b/src/exports/otio.nim
@@ -1,10 +1,10 @@
 import std/[json, os, sets, tables]
-from std/math import round
+from std/math import round, hypot, ceil, sin, cos, PI
 when defined(windows):
   import std/strutils
 
-import ../[action, ffmpeg, media, timeline]
-import ../util/[fun, rational]
+import ../[action, ffmpeg, log, media, timeline]
+import ../util/[color, fun, rational]
 
 #[
 OpenTimelineIO (.otio) export, compatible with Adobe Premiere Pro.
@@ -78,20 +78,66 @@ proc speedEffect(scalar: float): JsonNode =
     "time_scalar": scalar
   }
 
-proc opacityEffect(rate: float): JsonNode =
+proc opacityEffect(rate: float, pct: float): JsonNode =
   effectNode("AE.ADBE Opacity", "Opacity", "", true, jarr(
-    startParam("Opacity", 1, %100.0, rate),
+    startParam("Opacity", 1, %pct, rate),
     startParam("Blend Mode", 2, %18, rate),
     startParam("Blend Mode", 3, %0, rate),
   ))
 
-proc motionEffect(rate: float, position: JsonNode, scalePct: float): JsonNode =
+proc rotationParam(actions: Actions, srcStart, srcDur: float, clipDur: int,
+    rate: float): JsonNode =
+  ## Premiere Motion "Rotation" (id 5), in degrees, clockwise-positive (matching
+  ## auto-editor). `spin` turns at a constant rate, so two linear keyframes (start
+  ## angle -> end angle over the clip) reproduce it exactly; `rotate` is a fixed
+  ## angle. Note: Premiere rotates in place and does not expand the canvas the way
+  ## auto-editor's spin does, so the corners are not auto-fit (they clip / show
+  ## through) unless you also scale the clip down.
+  # Premiere caps Rotation near +/-90 turns. A spin that exceeds it is written as
+  # a sawtooth: sweep in <=89-turn segments and reset on a 360-degree multiple,
+  # which is the same orientation so the reset is invisible, keeping every keyframe
+  # value within the cap. 89*360 leaves margin below the cap for a non-zero start.
+  const maxDeg = 32040.0
+  for a in actions:
+    if a.kind == actSpin:
+      let startDeg = rotDeg(a.sStart).float
+      if srcDur <= 1.0 or clipDur <= 1:
+        return startParam("Rotation", 5, %startDeg, rate)
+      # angle(local) = startDeg + rate_deg_per_sec * local/fps (fps == `rate`).
+      let totalDeg = a.sRate.float * float(clipDur - 1) / rate
+      let lastPos = srcStart + srcDur - 1.0
+      let span = srcDur - 1.0
+      let kfs = newJArray()
+      kfs.add %*{"Position": rationalTime(rate, srcStart), "Value": startDeg}
+      if abs(totalDeg) <= maxDeg:
+        kfs.add %*{"Position": rationalTime(rate, lastPos),
+                   "Value": startDeg + totalDeg}
+      else:
+        let sign = (if totalDeg < 0: -1.0 else: 1.0)
+        let n = int(abs(totalDeg) / maxDeg)
+        var resets = 0
+        for k in 1 .. n:
+          let posK = round(srcStart + (k.float * maxDeg / abs(totalDeg)) * span)
+          if posK + 1.0 >= lastPos: break  # no room before the end; fold into last
+          kfs.add %*{"Position": rationalTime(rate, posK),
+                     "Value": startDeg + sign * maxDeg}
+          kfs.add %*{"Position": rationalTime(rate, posK + 1.0), "Value": startDeg}
+          resets = k
+        kfs.add %*{"Position": rationalTime(rate, lastPos),
+                   "Value": startDeg + totalDeg - sign * maxDeg * resets.float}
+      return %*{"DisplayName": "Rotation", "ID": 5, "Keyframes": kfs}
+    if a.kind == actRotate:
+      return startParam("Rotation", 5, %rotDeg(a.rStart).float, rate)
+  startParam("Rotation", 5, %0.0, rate)
+
+proc motionEffect(rate: float, position: JsonNode, scalePct: float,
+    rotation: JsonNode): JsonNode =
   effectNode("AE.ADBE Motion", "Motion", "", true, jarr(
     startParam("Position", 1, position, rate),
     startParam("Scale", 2, %scalePct, rate),
     startParam("Scale Width", 3, %scalePct, rate),
     startParam(" ", 4, %true, rate),
-    startParam("Rotation", 5, %0.0, rate),
+    rotation,
     startParam("Anchor Point", 6, center(), rate),
     startParam("Anti-flicker Filter", 7, %0.0, rate),
     startParam("Crop Left", 8, %0.0, rate),
@@ -100,28 +146,106 @@ proc motionEffect(rate: float, position: JsonNode, scalePct: float): JsonNode =
     startParam("Crop Bottom", 11, %0.0, rate),
   ))
 
+proc contentSize(actions: Actions, srcW, srcH: float): (float, float) =
+  ## Size of the picture's bounding box after rotation expansion, matching the
+  ## render: `spin` rotates inside a fixed square sized to the diagonal (so it never
+  ## clips at any angle), while static `rotate` expands to the rotated bounding box.
+  for a in actions:
+    if a.kind == actSpin:
+      let side = float((int(ceil(hypot(srcW, srcH))) + 1) and not 1)
+      return (side, side)
+    if a.kind == actRotate:
+      let rad = rotDeg(a.rStart).float * PI / 180.0
+      return (abs(srcW * cos(rad)) + abs(srcH * sin(rad)),
+              abs(srcW * sin(rad)) + abs(srcH * cos(rad)))
+  (srcW, srcH)
+
 proc motionFor(actions: Actions, mi: MediaInfo, res: (int32, int32),
-    rate: float): JsonNode =
-  ## Translate an overlay `pos` placement into Premiere's intrinsic Motion.
-  ## auto-editor's pos is a top-left corner in canvas px plus a multiplier of the
-  ## source's native size; Premiere's Position is the clip centre as a fraction of
-  ## the frame and Scale is a percentage of native size. Without a `pos` the clip
-  ## stays centred at native scale. Only the first keyframe is read, so an animated
-  ## slide collapses to its start position (keyframe export is a separate task).
+    srcStart, srcDur: float, clipDur: int, rate: float): JsonNode =
+  ## Translate auto-editor's placement/scale into Premiere's intrinsic Motion. With
+  ## an explicit `pos`, the picture is sized by its scale multiplier and positioned
+  ## by the (rotation-expanded) content box's top-left corner. Without `pos` it is
+  ## fit-and-centred to the canvas like the base layer (scaleWithPad). Scale is a
+  ## percentage of the source's native size; Position is the clip centre as a
+  ## fraction of the frame. Only the first pos keyframe is read (static placement).
+  let (sw, sh) = mi.getRes()
+  let srcW = sw.float
+  let srcH = sh.float
+  let (effW, effH) = contentSize(actions, srcW, srcH)
+  let canvasW = res[0].float
+  let canvasH = res[1].float
+
   var position = center()
   var scalePct = 100.0
+  var hasPos = false
   for a in actions:
     if a.kind == actPos:
-      let (srcW, srcH) = mi.getRes()
+      hasPos = true
       let scale = (if a.pscaleKf.len > 0: a.pscaleKf[0].float else: 1.0)
       let x = (if a.pxKf.len > 0: a.pxKf[0].float else: 0.0)
       let y = (if a.pyKf.len > 0: a.pyKf[0].float else: 0.0)
-      let cx = x + srcW.float * scale / 2.0
-      let cy = y + srcH.float * scale / 2.0
-      position = %*{"X": cx / res[0].float, "Y": cy / res[1].float}
+      position = %*{"X": (x + effW * scale / 2.0) / canvasW,
+                    "Y": (y + effH * scale / 2.0) / canvasH}
       scalePct = scale * 100.0
       break
-  motionEffect(rate, position, scalePct)
+  if not hasPos:
+    # Fit the (rotation-expanded) content to the canvas and centre it. For an
+    # un-rotated source this is the plain fit; for spin it shrinks so the diagonal
+    # square fits, so the picture never clips as it turns.
+    scalePct = min(canvasW / effW, canvasH / effH) * 100.0
+
+  scalePct = round(scalePct * 10000.0) / 10000.0
+  motionEffect(rate, position, scalePct,
+    rotationParam(actions, srcStart, srcDur, clipDur, rate))
+
+proc pctVal(v: float): float =
+  ## auto-editor opacity is 0.0..1.0; Premiere wants a 0..100 percentage. Round off
+  ## float32 storage noise (opacity is quantized to unorm16).
+  round(v * 100.0 * 10000.0) / 10000.0
+
+proc opacityKeyframes(act: Action, srcStart, srcDur: float, clipDur: int,
+    rate: float): JsonNode =
+  ## A Premiere Keyframes array for an animated opacity, positioned across the
+  ## clip's source range (matching `source_range`). An un-eased ramp is exact: one
+  ## keyframe per control point, linearly interpolated. An eased ramp is baked by
+  ## sampling auto-editor's own curve at a bounded resolution.
+  result = newJArray()
+  let n = act.kf.len
+  template kfNode(p: float, v: float): JsonNode =
+    %*{"Position": rationalTime(rate, srcStart + round(p * (srcDur - 1.0))),
+       "Value": pctVal(v)}
+  if not act.hasEase:
+    for i in 0 ..< n:
+      let p = (if n == 1: 0.0 else: i.float / float(n - 1))
+      result.add kfNode(p, act.kf[i].float)
+  else:
+    let animLen =
+      case act.easeDurUnit
+      of duClip: clipDur
+      of duSec: max(1, int(round(act.easeDur.float * rate)))
+      of duFrames: max(1, int(round(act.easeDur.float)))
+    let denom = max(1, clipDur - 1)
+    let samples = min(denom, 60)
+    for s in 0 .. samples:
+      let local = int(round(s.float / samples.float * denom.float))
+      let prog = applyEase(act.easeCurve, clipT(local, animLen))
+      result.add kfNode(local.float / denom.float, sampleKf(act.kf, prog).float)
+
+proc opacityFor(actions: Actions, srcStart, srcDur: float, clipDur: int,
+    rate: float): JsonNode =
+  ## Premiere's intrinsic Opacity effect. A single value is a fixed StartValue; a
+  ## keyframe ramp becomes an animated Keyframes parameter.
+  for a in actions:
+    if a.kind == actOpacity and a.kf.len > 0:
+      if a.kf.len == 1:
+        return opacityEffect(rate, pctVal(a.kf[0].float))
+      return effectNode("AE.ADBE Opacity", "Opacity", "", true, jarr(
+        %*{"DisplayName": "Opacity", "ID": 1,
+           "Keyframes": opacityKeyframes(a, srcStart, srcDur, clipDur, rate)},
+        startParam("Blend Mode", 2, %18, rate),
+        startParam("Blend Mode", 3, %0, rate),
+      ))
+  opacityEffect(rate, 100.0)
 
 proc invertEffect(rate: float): JsonNode =
   effectNode("AE.ADBE Invert", "Invert", "", false, jarr(
@@ -157,8 +281,12 @@ proc trackPanner(): JsonNode =
     keyframeParam("Balance", 0),
   ))
 
-proc mediaRef(mi: MediaInfo, rate: float, tb: AVRational): JsonNode =
-  let availDur = float(int(mi.duration * tb))
+proc mediaRef(mi: MediaInfo, rate, availDur: float): JsonNode =
+  ## `availDur` is the available media length in frames. For a still image this
+  ## must cover the clip's source range, not the still's 1-frame "duration":
+  ## Premiere maps a clip's effect-keyframe times against the media extent, so a
+  ## 1-frame available_range stretches every keyframe animation (e.g. spin runs at
+  ## half speed).
   %*{
     "DEFAULT_MEDIA": {
       "OTIO_SCHEMA": "ExternalReference.1",
@@ -197,10 +325,16 @@ proc buildClip(clip: Clip, actions: Actions, mi: MediaInfo, rate: float,
   let srcStart = round(clip.offset.float * speed)
   let srcDur = max(1.0, round(clip.dur.float * speed))
 
+  # Available media length (frames). A still has ~no real duration, so size its
+  # range to cover the clip; otherwise Premiere mis-scales its keyframe times.
+  let realAvail = float(int(mi.duration * tb))
+  let availDur = (if mi.v.len > 0 and realAvail <= 1.0: srcStart + srcDur
+                  else: realAvail)
+
   let effectsArr = newJArray()
   if isVideo:
-    effectsArr.add opacityEffect(rate)
-    effectsArr.add motionFor(actions, mi, res, rate)
+    effectsArr.add opacityFor(actions, srcStart, srcDur, clip.dur.int, rate)
+    effectsArr.add motionFor(actions, mi, res, srcStart, srcDur, clip.dur.int, rate)
     if hasAction(actions, actInvert):
       effectsArr.add invertEffect(rate)
     if hasAction(actions, actHflip):
@@ -210,7 +344,10 @@ proc buildClip(clip: Clip, actions: Actions, mi: MediaInfo, rate: float,
   else:
     effectsArr.add volumeEffect()
     effectsArr.add clipPanner(rate)
-  effectsArr.add speedEffect(speed)
+  # Premiere only writes a time warp on a re-timed clip; a no-op one at 1x makes
+  # it treat the clip as time-remapped and drop the intrinsic Opacity/Motion.
+  if speed != 1.0:
+    effectsArr.add speedEffect(speed)
 
   let meta = newJObject()
   if not isVideo:
@@ -237,7 +374,74 @@ proc buildClip(clip: Clip, actions: Actions, mi: MediaInfo, rate: float,
     "effects": effectsArr,
     "markers": newJArray(),
     "enabled": true,
-    "media_references": mediaRef(mi, rate, tb),
+    "media_references": mediaRef(mi, rate, availDur),
+    "active_media_reference_key": "DEFAULT_MEDIA"
+  }
+
+proc writeSolidPng(path: string, w, h: cint, bg: RGBColor) =
+  ## Encode a solid w×h RGB image to a PNG file. PNG is an image codec, so a single
+  ## encoded packet is the whole file. Used to materialise `-bg` as real media the
+  ## OTIO can reference (a generator/color-matte can't be carried portably).
+  let codec = avcodec_find_encoder(ID_PNG)
+  if codec == nil:
+    error "PNG encoder not found"
+  let ctx = avcodec_alloc_context3(codec)
+  if ctx == nil:
+    error "Could not allocate PNG encoder context"
+  ctx.width = w
+  ctx.height = h
+  ctx.pix_fmt = AV_PIX_FMT_RGB24
+  ctx.time_base = AVRational(num: 1, den: 1)
+  if avcodec_open2(ctx, codec, nil) < 0:
+    error "Could not open PNG encoder"
+
+  let frame = av_frame_alloc()
+  frame.format = AV_PIX_FMT_RGB24.cint
+  frame.width = w
+  frame.height = h
+  if av_frame_get_buffer(frame, 32) < 0:
+    error "Could not allocate PNG frame buffer"
+  discard av_frame_make_writable(frame)
+  for y in 0 ..< h:
+    let row = cast[ptr UncheckedArray[uint8]](
+      cast[int](frame.data[0]) + y.int * frame.linesize[0].int)
+    for x in 0 ..< w:
+      row[x * 3] = bg.red
+      row[x * 3 + 1] = bg.green
+      row[x * 3 + 2] = bg.blue
+
+  let pkt = av_packet_alloc()
+  if avcodec_send_frame(ctx, frame) < 0 or avcodec_receive_packet(ctx, pkt) < 0:
+    error "Could not encode background PNG"
+  var buf = newString(pkt.size)
+  copyMem(addr buf[0], pkt.data, pkt.size)
+  writeFile(path, buf)
+
+  av_packet_free(addr pkt)
+  av_frame_free(addr frame)
+  avcodec_free_context(addr ctx)
+
+proc bgClip(mi: MediaInfo, tl: v3, rate: float): JsonNode =
+  ## A full-frame background clip referencing the generated `-bg` PNG. No effects
+  ## of its own (opacity 100, fit-and-centre at native size = full frame, no
+  ## rotation) and no LinkID, so it stays an independent bottom layer.
+  %*{
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": {"PremierePro_OTIO": {
+      "OriginalChannelGroupIndex": 0, "SourceClipIndex": 0}},
+    "name": agSplitFile(mi.path).name,
+    "source_range": {
+      "OTIO_SCHEMA": "TimeRange.1",
+      "duration": rationalTime(rate, tl.len.float),
+      "start_time": rationalTime(rate, 0.0)
+    },
+    "effects": jarr(
+      opacityFor(aNil, 0.0, tl.len.float, tl.len.int, rate),
+      motionFor(aNil, mi, tl.res, 0.0, tl.len.float, tl.len.int, rate)
+    ),
+    "markers": newJArray(),
+    "enabled": true,
+    "media_references": mediaRef(mi, rate, tl.len.float),
     "active_media_reference_key": "DEFAULT_MEDIA"
   }
 
@@ -252,6 +456,28 @@ proc otioWrite*(name, output: string, tl: v3) =
 
   let children = newJArray()
 
+  # A non-default `-bg` is materialised as a solid PNG written next to the output
+  # and referenced as the bottom video track, so the colour shows wherever the
+  # picture doesn't cover the frame. (Premiere's color-matte generator references a
+  # project-local item by GUID and can't be carried portably, so it isn't used.)
+  var videoTrackNum = 0
+  if output != "-" and tl.bg != RGBColor(red: 0, green: 0, blue: 0):
+    let (dir, nm, _) = splitFile(output)
+    let pngPath = dir / (nm & "-bg.png")
+    writeSolidPng(pngPath, tl.res[0], tl.res[1], tl.bg)
+    videoTrackNum += 1
+    children.add %*{
+      "OTIO_SCHEMA": "Track.1",
+      "metadata": newJObject(),
+      "name": "Video " & $videoTrackNum,
+      "source_range": newJNull(),
+      "effects": newJArray(),
+      "markers": newJArray(),
+      "enabled": true,
+      "children": jarr(bgClip(initMediaInfo(pngPath), tl, rate)),
+      "kind": "Video"
+    }
+
   # LinkID groups the parts of one linked A/V clip in Premiere. The base video
   # clip j and the audio clips at index j (the same cut) share LinkID j+1;
   # independent `add:` overlay clips must get unique IDs past that range, or
@@ -263,7 +489,6 @@ proc otioWrite*(name, output: string, tl: v3) =
     maxAligned = max(maxAligned, atrack.len)
   var nextOverlayLink = maxAligned
 
-  var videoTrackNum = 0
   for vIdx, track in tl.v:
     let clipArr = newJArray()
     for j, clip in track:

--- a/src/exports/otio.nim
+++ b/src/exports/otio.nim
@@ -85,11 +85,11 @@ proc opacityEffect(rate: float): JsonNode =
     startParam("Blend Mode", 3, %0, rate),
   ))
 
-proc motionEffect(rate: float): JsonNode =
+proc motionEffect(rate: float, position: JsonNode, scalePct: float): JsonNode =
   effectNode("AE.ADBE Motion", "Motion", "", true, jarr(
-    startParam("Position", 1, center(), rate),
-    startParam("Scale", 2, %100.0, rate),
-    startParam("Scale Width", 3, %100.0, rate),
+    startParam("Position", 1, position, rate),
+    startParam("Scale", 2, %scalePct, rate),
+    startParam("Scale Width", 3, %scalePct, rate),
     startParam(" ", 4, %true, rate),
     startParam("Rotation", 5, %0.0, rate),
     startParam("Anchor Point", 6, center(), rate),
@@ -99,6 +99,29 @@ proc motionEffect(rate: float): JsonNode =
     startParam("Crop Right", 10, %0.0, rate),
     startParam("Crop Bottom", 11, %0.0, rate),
   ))
+
+proc motionFor(actions: Actions, mi: MediaInfo, res: (int32, int32),
+    rate: float): JsonNode =
+  ## Translate an overlay `pos` placement into Premiere's intrinsic Motion.
+  ## auto-editor's pos is a top-left corner in canvas px plus a multiplier of the
+  ## source's native size; Premiere's Position is the clip centre as a fraction of
+  ## the frame and Scale is a percentage of native size. Without a `pos` the clip
+  ## stays centred at native scale. Only the first keyframe is read, so an animated
+  ## slide collapses to its start position (keyframe export is a separate task).
+  var position = center()
+  var scalePct = 100.0
+  for a in actions:
+    if a.kind == actPos:
+      let (srcW, srcH) = mi.getRes()
+      let scale = (if a.pscaleKf.len > 0: a.pscaleKf[0].float else: 1.0)
+      let x = (if a.pxKf.len > 0: a.pxKf[0].float else: 0.0)
+      let y = (if a.pyKf.len > 0: a.pyKf[0].float else: 0.0)
+      let cx = x + srcW.float * scale / 2.0
+      let cy = y + srcH.float * scale / 2.0
+      position = %*{"X": cx / res[0].float, "Y": cy / res[1].float}
+      scalePct = scale * 100.0
+      break
+  motionEffect(rate, position, scalePct)
 
 proc invertEffect(rate: float): JsonNode =
   effectNode("AE.ADBE Invert", "Invert", "", false, jarr(
@@ -168,7 +191,8 @@ proc hasAction(actions: Actions, kind: ActionKind): bool =
       return true
 
 proc buildClip(clip: Clip, actions: Actions, mi: MediaInfo, rate: float,
-    tb: AVRational, isVideo: bool, linkId: int, nbCh: int): JsonNode =
+    tb: AVRational, isVideo: bool, linkId: int, nbCh: int,
+    res: (int32, int32)): JsonNode =
   let speed = clipSpeed(actions)
   let srcStart = round(clip.offset.float * speed)
   let srcDur = max(1.0, round(clip.dur.float * speed))
@@ -176,7 +200,7 @@ proc buildClip(clip: Clip, actions: Actions, mi: MediaInfo, rate: float,
   let effectsArr = newJArray()
   if isVideo:
     effectsArr.add opacityEffect(rate)
-    effectsArr.add motionEffect(rate)
+    effectsArr.add motionFor(actions, mi, res, rate)
     if hasAction(actions, actInvert):
       effectsArr.add invertEffect(rate)
     if hasAction(actions, actHflip):
@@ -228,16 +252,42 @@ proc otioWrite*(name, output: string, tl: v3) =
 
   let children = newJArray()
 
-  for i, track in tl.v:
+  # LinkID groups the parts of one linked A/V clip in Premiere. The base video
+  # clip j and the audio clips at index j (the same cut) share LinkID j+1;
+  # independent `add:` overlay clips must get unique IDs past that range, or
+  # Premiere fuses them with the audio (showing it as "[V]" and muting it).
+  var maxAligned = 0
+  if tl.v.len > 0:
+    maxAligned = max(maxAligned, tl.v[0].len)
+  for atrack in tl.a:
+    maxAligned = max(maxAligned, atrack.len)
+  var nextOverlayLink = maxAligned
+
+  var videoTrackNum = 0
+  for vIdx, track in tl.v:
     let clipArr = newJArray()
     for j, clip in track:
+      # An audio-only timeline that gained `add:` overlays has a synthesized base
+      # track with no source file; it exists only as a render canvas, so there is
+      # nothing to reference here. Skip it (and any track left empty).
+      if clip.src == nil:
+        continue
+      var linkId: int
+      if vIdx == 0:
+        linkId = j + 1
+      else:
+        inc nextOverlayLink
+        linkId = nextOverlayLink
       let actions = tl.effects[clip.effects]
       clipArr.add buildClip(clip, actions, ptrToMi[clip.src], rate, tb = tl.tb,
-        isVideo = true, linkId = j + 1, nbCh = nbCh)
+        isVideo = true, linkId = linkId, nbCh = nbCh, res = tl.res)
+    if clipArr.len == 0:
+      continue
+    videoTrackNum += 1
     children.add %*{
       "OTIO_SCHEMA": "Track.1",
       "metadata": newJObject(),
-      "name": "Video " & $(i + 1),
+      "name": "Video " & $videoTrackNum,
       "source_range": nil,
       "effects": newJArray(),
       "markers": newJArray(),
@@ -251,7 +301,7 @@ proc otioWrite*(name, output: string, tl: v3) =
     for j, clip in track:
       let actions = tl.effects[clip.effects]
       clipArr.add buildClip(clip, actions, ptrToMi[clip.src], rate, tb = tl.tb,
-        isVideo = false, linkId = j + 1, nbCh = nbCh)
+        isVideo = false, linkId = j + 1, nbCh = nbCh, res = tl.res)
     children.add %*{
       "OTIO_SCHEMA": "Track.1",
       "metadata": {"PremierePro_OTIO": {"AudioChannels": {

--- a/src/ffmpeg.nim
+++ b/src/ffmpeg.nim
@@ -15,6 +15,8 @@ proc av_inv_q*(a: AVRational): AVRational {.importc, header: "<libavutil/rationa
 proc av_parse_ratio(q: ptr AVRational, str: cstring, max: cint, log_offset: cint,
     log_ctx: pointer): cint {.importc, header: "<libavutil/parseutils.h>".}
 proc av_cmp_q(a, b: AVRational): cint {.importc, header: "<libavutil/rational.h>".}
+proc av_reduce(dst_num, dst_den: ptr cint, num, den, max: int64): cint {.importc,
+  header: "<libavutil/rational.h>".}
 
 func `+`*(a, b: AVRational): AVRational = av_add_q(a, b)
 func `-`*(a, b: AVRational): AVRational = av_sub_q(a, b)
@@ -25,9 +27,11 @@ func `~=`*(a, b: AVRational): bool = av_cmp_q(a, b) == 0
 func `~=`*[T: int64 | int32 | int](a: AVRational, b: T): bool =
   a ~= AVRational(num: b.cint, den: 1)
 func `*`*[T: int64 | int32](a: T, b: AVRational): AVRational =
-  AVRational(num: a.cint, den: 1) * b
+  discard av_reduce(addr result.num, addr result.den,
+    a.int64 * b.num.int64, b.den.int64, high(cint).int64)
 func `/`*[T: int64 | int32](a: T, b: AVRational): AVRational =
-  AVRational(num: a.cint, den: 1) / b
+  discard av_reduce(addr result.num, addr result.den,
+    a.int64 * b.den.int64, b.num.int64, high(cint).int64)
 converter toDouble*(r: AVRational): cdouble = av_q2d(r)
 
 func toAVRational*(s: string): AVRational {.raises: [ValueError].} =


### PR DESCRIPTION
Export add: overlays as their own video tracks instead of dropping everything above the base. File defs now report the source's real frame size, and still images get a finite duration so Premiere holds them.

OTIO: map an overlay's pos:x:y:scale to the Motion effect, and give each overlay a unique link ID so Premiere stops fusing overlays with the audio. The audio-only background canvas (nil src) is skipped in both exports rather than crashing.