### PR TITLE
Clip subtitle cues to clip boundaries when remuxing

### DIFF
--- a/src/ffmpeg.nim
+++ b/src/ffmpeg.nim
@@ -720,6 +720,8 @@ proc av_interleaved_write_frame*(s: ptr AVFormatContext,
     pkt: ptr AVPacket): cint {.importc, header: "<libavformat/avformat.h>".}
 proc av_packet_rescale_ts*(pkt: ptr AVPacket, tb_src: AVRational,
     tb_dst: AVRational) {.importc, header: "<libavcodec/packet.h>".}
+proc av_rescale_q*(a: int64, bq, cq: AVRational): int64 {.importc,
+    header: "<libavutil/mathematics.h>".}
 
 # Filters
 type

--- a/src/render/subtitle.nim
+++ b/src/render/subtitle.nim
@@ -1,9 +1,12 @@
 import ../[av, log, ffmpeg, timeline]
 import ../util/rational
 
-# Simple subtitle remuxing: copy subtitle packets from source, adjusting timestamps
-# Note: This approach works well for text-based subtitles (SRT, ASS, WebVTT, etc.)
-# For bitmap subtitles (DVD/PGS), the timestamps are adjusted but the visual data remains unchanged
+# Remux subtitle packets from source onto the cut timeline, clipping each cue's
+# visible window to its clip boundary. A cue that overlaps a cut-in point is kept
+# (its start clamped to the cut) and one that runs past a cut-out is shortened, so
+# subtitles stay in sync with the edited video instead of dropping or bleeding over.
+# Works for text subs (SRT/ASS/WebVTT); bitmap subs (DVD/PGS) pass through with
+# adjusted timing only.
 proc remuxSubtitles*(sourcePath: string, layer: seq[Clip], outputStream: ptr AVStream,
     output: var OutputContainer, timelineTb: AVRational) =
   if layer.len == 0:
@@ -15,6 +18,8 @@ proc remuxSubtitles*(sourcePath: string, layer: seq[Clip], outputStream: ptr AVS
 
   let formatCtx = srcContainer.formatContext
   let outTb = outputStream.time_base
+  # timelineTb is the frame rate, so one frame lasts 1/timelineTb seconds.
+  let frameTb = av_inv_q(timelineTb)
 
   for clip in layer:
     if clip.stream >= srcContainer.subtitle.len:
@@ -24,65 +29,55 @@ proc remuxSubtitles*(sourcePath: string, layer: seq[Clip], outputStream: ptr AVS
     let stream = formatCtx.streams[streamIndex]
     let srcTb = stream.time_base
 
-    # Seek to the clip's offset position in source timebase
-    # Note: timelineTb is actually the frame rate, so the actual timebase is 1/timelineTb
-    let seekPts = int64(float64(clip.offset) / (float64(timelineTb) * float64(srcTb)))
+    # The clip selects source interval [clipStartSrc, clipEndSrc) in source ticks.
+    let clipStartSrc = av_rescale_q(clip.offset, frameTb, srcTb)
+    let clipEndSrc = av_rescale_q(clip.offset + clip.dur, frameTb, srcTb)
 
-    # Calculate the end position in source timebase
-    let clipEndInSrcTb = int64(float64(clip.offset + clip.dur) / (float64(timelineTb) * float64(srcTb)))
-
-    # Seek to start of clip
-    if seekPts > 0:
-      srcContainer.seek(seekPts, backward = true, stream = stream)
+    # Seek backward so a cue already on screen at the cut-in is read too.
+    if clipStartSrc > 0:
+      srcContainer.seek(clipStartSrc, backward = true, stream = stream)
 
     var packet = av_packet_alloc()
     if packet == nil:
       error "Could not allocate subtitle packet"
     defer: av_packet_free(addr packet)
 
-    # Read and copy packets for this clip
     while av_read_frame(formatCtx, packet) >= 0:
       defer: av_packet_unref(packet)
 
-      if packet.stream_index == streamIndex:
-        # Check if packet is within the clip range
-        if packet.pts != AV_NOPTS_VALUE and packet.pts >= seekPts and packet.pts < clipEndInSrcTb:
-          # Calculate new timestamp in output timebase
-          # Step 1: Get relative position in source timebase
-          let relativeStartInSrcTb = packet.pts - seekPts
-          # Step 2: Convert to timeline units (frames)
-          let relativeStartInFrames = int64(float64(relativeStartInSrcTb) * float64(timelineTb) * float64(srcTb))
-          # Step 3: Calculate absolute position in frames
-          let absoluteFramePos = clip.start + relativeStartInFrames
-          # Step 4: Convert from frames to output timebase
-          let newPts = int64(float64(absoluteFramePos) / (float64(timelineTb) * float64(outTb)))
+      if packet.stream_index != streamIndex or packet.pts == AV_NOPTS_VALUE:
+        continue
 
-          # Create output packet with adjusted timestamps
-          var outPacket: AVPacket
-          outPacket.time_base = outTb
-          outPacket.stream_index = outputStream.index
+      let cueStart = packet.pts
+      let hasDur = packet.duration != AV_NOPTS_VALUE and packet.duration > 0
+      let cueEnd = (if hasDur: cueStart + packet.duration else: cueStart)
 
-          if av_packet_ref(addr outPacket, packet) < 0:
-            error "Failed to reference subtitle packet"
+      # Packets arrive in pts order, so once a cue starts at/after the window, done.
+      if cueStart >= clipEndSrc:
+        break
 
-          # Convert timestamps to timeline timebase
-          outPacket.pts = newPts
-          if packet.dts != AV_NOPTS_VALUE:
-            let relativeDtsInSrcTb = packet.dts - seekPts
-            let relativeDtsInFrames = int64(float64(relativeDtsInSrcTb) * float64(timelineTb) * float64(srcTb))
-            let absoluteDtsFramePos = clip.start + relativeDtsInFrames
-            outPacket.dts = int64(float64(absoluteDtsFramePos) / (float64(timelineTb) * float64(outTb)))
-          else:
-            outPacket.dts = AV_NOPTS_VALUE
+      # Keep any cue overlapping the window. With unknown duration we can't tell if
+      # an earlier-starting cue still overlaps, so fall back to start-inside.
+      let overlaps = (if hasDur: cueEnd > clipStartSrc else: cueStart >= clipStartSrc)
+      if not overlaps:
+        continue
 
-          if packet.duration != AV_NOPTS_VALUE:
-            outPacket.duration = int64(float64(packet.duration) * float64(timelineTb) * float64(srcTb) / (
-                float64(timelineTb) * float64(outTb)))
+      # Intersect cue with the window, then map source -> timeline frames -> output.
+      let visStart = max(cueStart, clipStartSrc)
+      let startFrame = clip.start + av_rescale_q(visStart - clipStartSrc, srcTb, frameTb)
+      let newPts = av_rescale_q(startFrame, frameTb, outTb)
 
-          # Mux the packet
-          output.mux(outPacket)
-          av_packet_unref(addr outPacket)
+      var outPacket: AVPacket
+      if av_packet_ref(addr outPacket, packet) < 0:
+        error "Failed to reference subtitle packet"
+      outPacket.stream_index = outputStream.index
+      outPacket.time_base = outTb
+      outPacket.pts = newPts
+      outPacket.dts = newPts  # subtitle streams have no reordering; keep dts == pts
+      if hasDur:
+        let visEnd = min(cueEnd, clipEndSrc)
+        let endFrame = clip.start + av_rescale_q(visEnd - clipStartSrc, srcTb, frameTb)
+        outPacket.duration = max(1'i64, av_rescale_q(endFrame, frameTb, outTb) - newPts)
 
-        elif packet.pts != AV_NOPTS_VALUE and packet.pts >= clipEndInSrcTb:
-          # We've passed the end of this clip
-          break
+      output.mux(outPacket)
+      av_packet_unref(addr outPacket)


### PR DESCRIPTION
Cues were filtered by start position: one still on screen at a cut-in was dropped (pts < clip start), and one running past a cut-out kept its full duration and bled into the next segment. Now keep any cue overlapping the clip window, clamping its visible start/end to the boundary.