### PR TITLE
Add mask and confine actions with feather

### DIFF
--- a/ae.nimble
+++ b/ae.nimble
@@ -788,7 +788,7 @@ proc setupCommonFlags(packages: seq[Package], kind: CrossKind = native): string 
 
   let enableDemuxers = enableMuxers & @["aac", "loas", "image2", "png_pipe", "mpegts"]
 
-  var filters = "aformat,abuffer,abuffersink,aresample,asetrate,atempo,anull,anullsrc,chromakey,colorkey,crop,drawbox,deesser,erosion,format,gblur,hflip,lenscorrection,loudnorm,lut,lutrgb,lutyuv,negate,overlay,pad,rgbashift,rotate,scale,vflip,volume".split(",")
+  var filters = "aformat,abuffer,abuffersink,alphamerge,aresample,asetrate,atempo,anull,anullsrc,chromakey,colorkey,crop,drawbox,deesser,erosion,format,gblur,geq,hflip,lenscorrection,loudnorm,lut,lutrgb,lutyuv,maskedmerge,negate,overlay,pad,rgbashift,rotate,scale,vflip,volume".split(",")
 
   for package in packages:
     if package.name == "libvpx":

--- a/src/action.nim
+++ b/src/action.nim
@@ -16,8 +16,8 @@ type
     actInvert = 20,
     actHflip, actVflip, actZoom, actOpacity, actBlur, actBrightness, actLuv, actLens,
     actRotate, actSpin, actDrawbox, actPos, actColorKey, actChromaKey, actLoop,
-    actErosion, actChoke, actAberration
-    # Can add 89 more [V] actions
+    actErosion, actChoke, actAberration, actMask, actConfine
+    # Can add 87 more [V] actions
 
   Easing* = enum  # interpolation curve for animations
     easeLinear, easeIn, easeOut, easeInOut
@@ -77,6 +77,13 @@ type
     of actAberration:
       abRh*, abRv*, abGh*, abGv*, abBh*, abBv*: int8
       abWrap*: bool          # edge: wrap around (true) vs smear the border (false)
+    of actMask, actConfine:
+      # `mask` shapes the clip's alpha; `confine` restricts following effects to
+      # this region. Shared geometry, in canvas pixels like drawbox.
+      mShape*: uint8         # 0=rect, 1=ellipse, 2=none (confine reset only)
+      mInvert*: bool         # swap inside/outside
+      mFeather*: uint8       # soft-edge width in px (0 = hard edge)
+      mX*, mY*, mW*, mH*: int32
 
   Actions* = distinct int # A fat pointer to a list of action in atf-8 format.
 
@@ -186,6 +193,10 @@ Simple form `aberration[:h[:v[:edge]]]`: split red and blue symmetrically by `h`
 Per-channel form: pass `key=value` pairs drawn from `rh`, `rv`, `gh`, `gv`, `bh`, `bv` (signed pixel shift for each channel/axis, default 0) plus `edge`, e.g. `aberration:rh=8:bh=-8:gv=2:edge=wrap`."""),
   ActionDef(name: "loop", flags: {afVideo},
     help: "Loop the clip's source back to its start when it runs out of frames, instead of ending. Useful for overlays whose source (e.g. a short gif) is shorter than the section it covers, e.g. `add:logo.gif,loop`."),
+  ActionDef(name: "mask", flags: {afVideo}, argSpec: "shape:x:y:w:h[:feather][:invert]",
+    help: "Cut the picture to a `rect` or `ellipse`, making everything outside the shape transparent. `x`/`y` are the top-left corner and `w`/`h` the size in pixels (for an ellipse, the bounding box). The optional `feather` softens the edge by that many pixels (0 = hard, the default); append `:invert` to hide the inside instead. On the base (bottom) track there is nothing to reveal, so the masked-out area is filled with the timeline background (`-bg`) instead; on an overlay it reveals the track below. Good for circular/rounded picture-in-picture, vignettes, and crop-to-shape. Example: `add:cam.mp4,pos:900:540:0.3,mask:ellipse:640:360:300:300:40`."),
+  ActionDef(name: "confine", flags: {afVideo}, argSpec: "[shape:x:y:w:h[:feather][:invert]]",
+    help: "Restrict the adjustment effects that follow it (`blur`, `brightness`, `brighthue`, `contrast`, `saturation`, `invert`, `erosion`, `aberration`) to a `rect` or `ellipse` region, leaving the rest of the picture untouched. Stays in effect until the next `confine` changes the region; a bare `confine` with no arguments resets to the full frame. `x`/`y`/`w`/`h` are in pixels; the optional `feather` fades the effect in over that many edge pixels, and `:invert` affects everything outside the region instead. Geometry effects (zoom, rotate, pos, ...) are unaffected. Example: `confine:rect:400:300:200:80,blur:30` blurs only the box, e.g. to censor a face or plate."),
 ]
 
 # Effects whose value can be a keyframe ramp (the `afAnimatable` actions).
@@ -285,6 +296,46 @@ proc parseEasing(spec: string): Easing {.raises: [ActionParseError].} =
   of "inout", "in-out": easeInOut
   else: raise newException(ActionParseError, "Unknown easing: " & spec)
 
+proc parseShapeRegion(parts: seq[string], kind: ActionKind,
+    name: string): Action {.raises: [ActionParseError].} =
+  ## Shared `shape:x:y:w:h[:feather][:invert]` geometry for `mask` and `confine`.
+  if parts.len < 6 or parts.len > 8:
+    raise newException(ActionParseError,
+      name & " requires shape:x:y:w:h[:feather][:invert]")
+  let shape = case parts[1]
+    of "rect": 0'u8
+    of "ellipse": 1'u8
+    else: raise newException(ActionParseError, name & " shape must be rect or ellipse")
+  var coords: array[4, int32]
+  for idx in 0 ..< 4:
+    try:
+      coords[idx] = int32(parseInt(parts[idx + 2]))
+    except ValueError:
+      raise newException(ActionParseError, "Invalid integer value")
+  if coords[2] <= 0 or coords[3] <= 0:
+    raise newException(ActionParseError, name & " width and height must be positive")
+  # Trailing tokens after the coords: `invert` (literal) and/or `feather` (px).
+  var inv = false
+  var feather = 0
+  for idx in 6 ..< parts.len:
+    if parts[idx] == "invert":
+      inv = true
+    else:
+      try:
+        feather = parseInt(parts[idx])
+      except ValueError:
+        raise newException(ActionParseError, "Unknown " & name & " option: " & parts[idx])
+      if feather < 0 or feather > 255:
+        raise newException(ActionParseError, name & " feather must be in [0, 255]")
+  result = Action(kind: kind)  # branch fields assigned after (shared by both kinds)
+  result.mShape = shape
+  result.mInvert = inv
+  result.mFeather = uint8(feather)
+  result.mX = coords[0]
+  result.mY = coords[1]
+  result.mW = coords[2]
+  result.mH = coords[3]
+
 func parseAction*(val: string): Action {.raises: [ActionParseError].} =
   if val == "invert":
     return Action(kind: actInvert)
@@ -296,8 +347,15 @@ func parseAction*(val: string): Action {.raises: [ActionParseError].} =
     return Action(kind: actLoop)
   if val == "erosion":
     return Action(kind: actErosion)
+  if val == "confine":  # bare = reset to full frame
+    return Action(kind: actConfine, mShape: 2)
 
   let parts = val.split(":")
+
+  if parts[0] == "mask":
+    return parseShapeRegion(parts, actMask, "mask")
+  if parts[0] == "confine":
+    return parseShapeRegion(parts, actConfine, "confine")
 
   # deesser takes positional args: intensity[:max[:freq]]
   if parts.len >= 2 and parts.len <= 4 and parts[0] == "deesser":
@@ -625,6 +683,12 @@ func kfStr(a: Action): string =
     else: parts.add $v
   parts.join("..")
 
+func maskStr(a: Action, name: string): string =
+  let shape = if a.mShape == 1: "ellipse" else: "rect"
+  result = name & ":" & shape & ":" & $a.mX & ":" & $a.mY & ":" & $a.mW & ":" & $a.mH
+  if a.mFeather > 0'u8: result &= ":" & $int(a.mFeather)
+  if a.mInvert: result &= ":invert"
+
 when not defined(nimscript):
   func `$`*(act: Action): string =
     case act.kind
@@ -686,6 +750,9 @@ when not defined(nimscript):
         if act.abBv != 0: ps.add "bv=" & $act.abBv
         if act.abWrap: ps.add "edge=wrap"
         "aberration:" & ps.join(":")
+    of actMask: maskStr(act, "mask")
+    of actConfine:
+      if act.mShape == 2: "confine" else: maskStr(act, "confine")
 
   func easeBytes(a: Action): int = (if a.hasEase: 6 else: 0)
 
@@ -703,6 +770,7 @@ when not defined(nimscript):
     of actDrawbox: 20
     of actBrightness, actOpacity: 2 + easeBytes(a) + a.kf.len * 2
     of actBlur, actZoom, actVolume: 2 + easeBytes(a) + a.kf.len * 4
+    of actMask, actConfine: 19  # header + flags + feather + 4x int32
 
   func len*(a: Actions): int =  # byte length
     if int(a) <= 1: 0
@@ -778,6 +846,18 @@ when not defined(nimscript):
         of actChoke:
           yield Action(kind: actChoke, chokeN: base[i + 1])
           i += 2
+        of actMask, actConfine:
+          let flags = base[i + 1]
+          let feather = base[i + 2]
+          var x, y, w, h: int32
+          copyMem(addr x, addr base[i + 3], sizeof(int32))
+          copyMem(addr y, addr base[i + 7], sizeof(int32))
+          copyMem(addr w, addr base[i + 11], sizeof(int32))
+          copyMem(addr h, addr base[i + 15], sizeof(int32))
+          yield Action(kind: kind, mShape: flags and 0x3'u8,
+            mInvert: (flags and 0x4'u8) != 0, mFeather: feather,
+            mX: x, mY: y, mW: w, mH: h)
+          i += 19
         of actAberration:
           yield Action(kind: actAberration,
             abRh: cast[int8](base[i + 1]), abRv: cast[int8](base[i + 2]),
@@ -917,6 +997,14 @@ when not defined(nimscript):
       of actChoke:
         base[i + 1] = a.chokeN
         i += 2
+      of actMask, actConfine:
+        base[i + 1] = a.mShape or (if a.mInvert: 0x4'u8 else: 0'u8)
+        base[i + 2] = a.mFeather
+        base.writeAt(i, 3, a.mX)
+        base.writeAt(i, 7, a.mY)
+        base.writeAt(i, 11, a.mW)
+        base.writeAt(i, 15, a.mH)
+        i += 19
       of actAberration:
         base.writeAt(i, 1, a.abRh)
         base.writeAt(i, 2, a.abRv)

--- a/src/render/video.nim
+++ b/src/render/video.nim
@@ -46,6 +46,38 @@ func fxId(kind: ActionKind, frame: ptr AVFrame, overlay = false,
 func packRGB(c: RGBColor): uint32 =
   uint32(c.red) shl 16 or uint32(c.green) shl 8 or uint32(c.blue)
 
+# Effects `confine` restricts to a region (adjustment effects only; geometry
+# effects like zoom/rotate/pos are intentionally left full-frame).
+const confinable = {actBlur, actBrightness, actLuv, actInvert, actErosion, actAberration}
+
+func maskGray(a: Action): string =
+  ## geq luma expression (0..255) for the matte: opaque inside the shape, black
+  ## outside, with an optional `feather`-pixel soft edge; `invert` flips it.
+  let f = a.mFeather.float
+  var cover: string  # 0..1 coverage, 1 = fully inside
+  if a.mShape == 1:  # ellipse
+    let cx = a.mX.float + a.mW.float / 2
+    let cy = a.mY.float + a.mH.float / 2
+    let rx = a.mW.float / 2
+    let ry = a.mH.float / 2
+    let rr2 = &"pow((X-{cx})/{rx},2)+pow((Y-{cy})/{ry},2)"
+    if f <= 0:
+      cover = &"lte({rr2},1)"
+    else:
+      # Feather (px) -> a normalized-radius band centered on the edge (r=1).
+      let nf = f / ((rx + ry) / 2)
+      cover = &"clip(0.5+(1-sqrt({rr2}))/{nf},0,1)"
+  else:              # rectangle
+    let x1 = a.mX + a.mW
+    let y1 = a.mY + a.mH
+    if f <= 0:
+      cover = &"between(X,{a.mX},{x1})*between(Y,{a.mY},{y1})"
+    else:
+      # Signed distance to the nearest edge (positive inside), ramped over f px.
+      let d = &"min(min(X-{a.mX},{x1}-X),min(Y-{a.mY},{y1}-Y))"
+      cover = &"clip(0.5+({d})/{f},0,1)"
+  if a.mInvert: &"255*(1-({cover}))" else: &"255*({cover})"
+
 # Keyframe index built from AVIndexEntry for efficient seeking
 type KeyframeIndex = object
   frames: seq[int] # sorted list of keyframe frame numbers
@@ -339,6 +371,12 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
   var fxKey: GraphKey
   var rotGraph: Graph = nil  # static source rotation, applied before the fit
   var rotKey: GraphKey
+  # Cached mask/confine mattes (gray8), rebuilt only when the region/size changes
+  # so the per-pixel geq runs once, not every frame.
+  var maskMatte: ptr AVFrame = nil
+  var maskMatteKey: GraphKey
+  var confineMatte: ptr AVFrame = nil
+  var confineMatteKey: GraphKey
   var needsScaling = false
 
   if args.scale != 1.0:
@@ -564,6 +602,124 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
     av_frame_free(addr bgFrame)
     av_frame_free(addr frame)
 
+  proc buildMaskMatte(w, h: cint, effect: Action): ptr AVFrame =
+    ## A gray8 matte: white where the mask/effect applies, black elsewhere, with
+    ## a feathered ramp between. Built once per (region, size) and cached.
+    var black = makeSolid(w, h, RGBColor(red: 0, green: 0, blue: 0))
+    black.pts = 0
+    let g = newGraph()
+    let src = g.add("buffer", bufArgsOf(black))
+    let geq = g.add("geq", &"lum={maskGray(effect)}")
+    let toGray = g.add("format", "pix_fmts=gray8")
+    let sink = g.add("buffersink")
+    g.linkNodes(@[src, geq, toGray, sink]).configure()
+    g.push(black)
+    result = g.pull()
+    g.cleanup()
+    av_frame_free(addr black)
+
+  proc cachedMatte(cache: var ptr AVFrame, key: var GraphKey,
+      frame: ptr AVFrame, effect: Action): ptr AVFrame =
+    ## Return the cached matte for `effect` at `frame`'s size, rebuilding only
+    ## when the region/feather/size changes. Caller must NOT free the result.
+    let k = fxId(effect.kind, frame, i0 = effect.mX, i1 = effect.mY,
+        i2 = effect.mW, i3 = effect.mH,
+        col = uint32(effect.mShape) or (if effect.mInvert: 0x100'u32 else: 0'u32) or
+          (uint32(effect.mFeather) shl 16))
+    if cache == nil or key != k:
+      if cache != nil: av_frame_free(addr cache)
+      cache = buildMaskMatte(frame.width, frame.height, effect)
+      key = k
+    cache
+
+  proc alphamergeOnto(frame0, matte: ptr AVFrame): ptr AVFrame =
+    ## Set `frame`'s alpha from the gray matte (cheap; no per-pixel geq).
+    var frame = frame0
+    frame.pts = 0
+    var m = av_frame_clone(matte)  # cached matte; push a fresh ref
+    m.pts = 0
+    let g = newGraph()
+    let fSrc = g.add("buffer", bufArgsOf(frame))
+    let mSrc = g.add("buffer", bufArgsOf(m))
+    let toGbrp = g.add("format", "pix_fmts=gbrp")
+    let am = g.add("alphamerge")
+    let toRgba = g.add("format", "pix_fmts=rgba")
+    let sink = g.add("buffersink")
+    discard g.linkNodes(@[fSrc, toGbrp])
+    g.link(toGbrp, am, 0, 0)
+    g.link(mSrc, am, 0, 1)
+    g.link(am, toRgba)
+    g.link(toRgba, sink)
+    g.configure()
+    g.pushIdx(0, frame)
+    g.pushIdx(1, m)
+    g.flushIdx(0)
+    g.flushIdx(1)
+    result = g.pull()
+    g.cleanup()
+    av_frame_free(addr m)
+    av_frame_free(addr frame)
+
+  proc overBg(frame0: ptr AVFrame): ptr AVFrame =
+    ## Flatten an alpha-shaped rgba frame over a solid `-bg` (base-track mask).
+    var top = frame0
+    var bgFrame = makeSolid(top.width, top.height, tl.bg)
+    top.pts = 0
+    bgFrame.pts = 0
+    let g = newGraph()
+    let bgSrc = g.add("buffer", bufArgsOf(bgFrame))
+    let fgSrc = g.add("buffer", bufArgsOf(top))
+    let ov = g.add("overlay", "format=yuv420")
+    g.link(bgSrc, ov, 0, 0)
+    g.link(fgSrc, ov, 0, 1)
+    g.link(ov, g.add("buffersink"))
+    g.configure()
+    g.pushIdx(0, bgFrame)
+    g.pushIdx(1, top)
+    g.flushIdx(0)
+    g.flushIdx(1)
+    result = g.pull()
+    g.cleanup()
+    av_frame_free(addr bgFrame)
+    av_frame_free(addr top)
+
+  proc maskedMergeRegion(saved, effected, matte: ptr AVFrame): ptr AVFrame =
+    ## Merge `effected` over `saved` weighted by the gray `matte` (in gbrp, so
+    ## the per-plane merge is clean), then back to the original format.
+    let origFmt = AVPixelFormat(saved.format)
+    saved.pts = 0
+    effected.pts = 0
+    var m = av_frame_clone(matte)  # cached matte; push a fresh ref
+    m.pts = 0
+    let g = newGraph()
+    let bSrc = g.add("buffer", bufArgsOf(saved))
+    let oSrc = g.add("buffer", bufArgsOf(effected))
+    let mSrc = g.add("buffer", bufArgsOf(m))
+    let bFmt = g.add("format", "pix_fmts=gbrp")
+    let oFmt = g.add("format", "pix_fmts=gbrp")
+    let mFmt = g.add("format", "pix_fmts=gbrp")
+    let mm = g.add("maskedmerge")
+    let toOrig = g.add("format", &"pix_fmts={$origFmt}")
+    let sink = g.add("buffersink")
+    discard g.linkNodes(@[bSrc, bFmt])
+    discard g.linkNodes(@[oSrc, oFmt])
+    discard g.linkNodes(@[mSrc, mFmt])
+    g.link(bFmt, mm, 0, 0)
+    g.link(oFmt, mm, 0, 1)
+    g.link(mFmt, mm, 0, 2)
+    g.link(mm, toOrig)
+    g.link(toOrig, sink)
+    g.configure()
+    g.pushIdx(0, saved)
+    g.pushIdx(1, effected)
+    g.pushIdx(2, m)
+    g.flushIdx(0)
+    g.flushIdx(1)
+    g.flushIdx(2)
+    result = g.pull()
+    g.cleanup()
+    av_frame_free(addr m)
+
   proc applyEffects(frame0: ptr AVFrame, effects: Actions, local, clipDur: int,
       isOverlay = false): ptr AVFrame =
     ## Apply one clip's effect chain to a frame, returning the (possibly new)
@@ -572,6 +728,12 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
     ## from `spin`.
     var frame = frame0
     let fps = tl.tb.float
+    # `confine` state: the active region's matte (lazily (re)built at the frame
+    # size of the next confined effect) and whether this iteration's effect is
+    # restricted to it.
+    var confineActive = false
+    var confineThis = false
+    var confineEffect: Action
     # Eased progress in [0, 1] for an animated action, using its own packed
     # easing curve + duration (defaults to linear over the whole clip).
     template prog(e: Action): float32 =
@@ -579,7 +741,8 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
 
     # Run `frame` through the effect graph identified by `key`, reusing the
     # previous graph when the key matches; `build` must add nodes to `fxGraph`
-    # and configure it.
+    # and configure it. When the active `confine` covers this effect, run it on a
+    # copy and merge only the masked region back over the untouched frame.
     template runFx(key: GraphKey, build: untyped) =
       let k = key
       if fxKey != k:
@@ -588,11 +751,22 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
         fxGraph = newGraph()
         build
         fxKey = k
-      fxGraph.push(frame)
-      av_frame_free(addr frame)
-      frame = fxGraph.pull()
+      if confineThis:
+        let matte = cachedMatte(confineMatte, confineMatteKey, frame, confineEffect)
+        let saved = av_frame_clone(frame)
+        fxGraph.push(frame)
+        av_frame_free(addr frame)
+        let effected = fxGraph.pull()
+        frame = maskedMergeRegion(saved, effected, matte)
+        av_frame_free(addr saved)
+        av_frame_free(addr effected)
+      else:
+        fxGraph.push(frame)
+        av_frame_free(addr frame)
+        frame = fxGraph.pull()
 
     for effect in effects:
+      confineThis = confineActive and effect.kind in confinable
       case effect.kind:
       of actSpeed, actVarispeed, actVolume, actDeesser, actDuck, actPos, actRotate, actLoop: discard
       of actSpin:
@@ -795,6 +969,18 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
           let toOrig = fxGraph.add("format", &"pix_fmts={$AVPixelFormat(frame.format)}")
           let bufferSink = fxGraph.add("buffersink")
           fxGraph.linkNodes(@[bufferSrc, toRgba, shift, toOrig, bufferSink]).configure()
+      of actMask:
+        # Shape the alpha from a cached matte via alphamerge (cheap per frame).
+        let matte = cachedMatte(maskMatte, maskMatteKey, frame, effect)
+        frame = alphamergeOnto(frame, matte)
+        if not isOverlay:
+          # Base layer: nothing below to reveal, so flatten the masked-out area
+          # over the timeline background.
+          frame = overBg(frame)
+      of actConfine:
+        # Set/clear the region the following adjustment effects are masked to.
+        confineActive = effect.mShape != 2
+        confineEffect = effect
     return frame
 
   proc decodeClipFrame(obj: VideoFrame): (ptr AVFrame, bool) =
@@ -1227,6 +1413,8 @@ proc makeNewVideoFrames*(output: var OutputContainer, tl: v3, args: mainArgs,
       fxGraph.cleanup()
     if rotGraph != nil:
       rotGraph.cleanup()
+    if maskMatte != nil: av_frame_free(addr maskMatte)
+    if confineMatte != nil: av_frame_free(addr confineMatte)
     sws_free_context(addr reformatCtx)
     av_frame_free(addr lastProcessedFrame)
     av_frame_free(addr nullFrame)


### PR DESCRIPTION
`mask` shapes a clip's alpha to a rect/ellipse; `confine` restricts the following adjustment effects to one. Shared 18->19 byte atf-8 record (shape/invert flags + feather byte + 4x int32).

A single gray8 matte (geq, with the feather ramp) is built once and cached across frames; the per-frame step is alphamerge (mask) / maskedmerge in gbrp (confine), so a static mask costs one geq, not one per frame. confine wraps each confinable effect inside runFx via the matte. Needs geq, maskedmerge, alphamerge filters.