### PR TITLE
Add content-aware edit method using TwelveLabs Pegasus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Different editing methods can be used together.
 auto-editor example.mp4 --edit "(or audio:0.03 motion:0.06)"
 ```
 
+### Content-Aware Cuts with TwelveLabs Pegasus
+The `pegasus` method goes beyond loudness and motion: it asks [TwelveLabs](https://twelvelabs.io) Pegasus, a video-understanding model, *what* is happening on screen and keeps only the moments that match a plain-language prompt. It is fully opt-in and changes nothing unless you ask for it.
+
+```
+# Keep only the parts where someone is speaking on camera.
+auto-editor example.mp4 --edit pegasus --pegasus-prompt "a person is speaking to the camera"
+
+# Combine it with the audio heuristic: keep loud parts OR action shots.
+auto-editor example.mp4 --edit "(or audio:0.04 pegasus)" --pegasus-prompt "an exciting action moment"
+```
+
+Set the `TWELVELABS_API_KEY` environment variable first. You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier. The video is uploaded to TwelveLabs for analysis. Use `--pegasus-prompt` for any multi-word prompt, since `--edit` tokens cannot contain spaces.
+
 You can also use `dB` unit, a volume unit familiar to video-editors (case-sensitive):
 ```
 auto-editor example.mp4 --edit audio:-19dB

--- a/src/analyze/pegasus.nim
+++ b/src/analyze/pegasus.nim
@@ -1,0 +1,146 @@
+## Content-aware editing powered by TwelveLabs Pegasus.
+##
+## Unlike `audio`/`motion`, which react to low-level signal energy, this method
+## asks Pegasus (a video-understanding model) a natural-language question about
+## the footage and marks the time spans that match as "loud" (label 1). For
+## example `--edit pegasus --pegasus-prompt "a person is speaking on camera"`
+## keeps the talking-head sections and cuts everything else, regardless of how
+## loud they are. (The prompt lives in its own flag because `--edit` tokens
+## cannot contain spaces.)
+##
+## It is fully opt-in: nothing here runs unless `pegasus` appears in `--edit`.
+## The local file is uploaded to TwelveLabs as an asset, segmented with the
+## `time_based_metadata` analysis mode, and the returned segments are rasterized
+## onto the timebase the same way `subtitle` spans are.
+##
+## Auth comes from the `TWELVELABS_API_KEY` environment variable. Network calls
+## go through `curl` (already required transitively and present everywhere),
+## mirroring how `main.nim` shells out to `yt-dlp`, so this adds no new build- or
+## link-time dependency such as an SSL-linked std/httpclient.
+
+import std/[json, math, os, osproc, strformat]
+
+import ../[ffmpeg, log]
+import ../util/rational
+
+const
+  apiBase = "https://api.twelvelabs.io/v1.3"
+  pollSeconds = 5
+  maxPollSeconds = 600  # Pegasus on a long clip can take several minutes.
+
+proc apiKey(): string =
+  result = getEnv("TWELVELABS_API_KEY", "")
+  if result == "":
+    error "pegasus: set the TWELVELABS_API_KEY environment variable.\n" &
+      "Get a free key at https://twelvelabs.io"
+
+proc curlJson(key: string, args: openArray[string]): JsonNode =
+  ## Run curl with the api key header (passed as an arg, never shell-expanded or
+  ## logged) and parse stdout as JSON. Args run without a shell, so the API key
+  ## and JSON body need no escaping. Mirrors how `main.nim` shells out to yt-dlp.
+  let full = @["-sS", "-H", "x-api-key: " & key] & @args
+  let output = try:
+      execProcess("curl", args = full, options = {poUsePath})
+    except OSError:
+      error "pegasus: `curl` must be installed and on PATH."
+  try:
+    result = parseJson(output)
+  except JsonParsingError:
+    error "pegasus: could not parse TwelveLabs response (is curl installed?)."
+  # The TwelveLabs API reports HTTP errors as a JSON body of {code, message}.
+  if result.kind == JObject and result.hasKey("code") and result.hasKey("message"):
+    error &"pegasus: TwelveLabs API error: {result[\"message\"].getStr}"
+
+proc uploadAsset(key, path: string): string =
+  ## Upload the local file as a `direct` asset and wait until it is ready.
+  let resp = curlJson(key, [apiBase & "/assets",
+    "-F", "method=direct", "-F", "file=@" & path])
+  let assetId = resp{"_id"}.getStr
+  if assetId == "":
+    error "pegasus: upload did not return an asset id."
+
+  for _ in 0 ..< (maxPollSeconds div pollSeconds):
+    let status = curlJson(key, [apiBase & "/assets/" & assetId]){"status"}.getStr
+    case status
+    of "ready": return assetId
+    of "failed": error "pegasus: TwelveLabs failed to process the upload."
+    else: sleep(pollSeconds * 1000)
+  error "pegasus: timed out waiting for the upload to be processed."
+
+proc runSegmentation(key, assetId, prompt: string, minSeg: float): JsonNode =
+  ## Kick off a time-based-metadata task and poll it to completion. Returns the
+  ## decoded segment object: {"match": [{start_time, end_time, metadata}, ...]}.
+  let body = $(%*{
+    "video": {"type": "asset_id", "asset_id": assetId},
+    "model_name": "pegasus1.5",
+    "analysis_mode": "time_based_metadata",
+    "min_segment_duration": minSeg,
+    "response_format": {
+      "type": "segment_definitions",
+      "segment_definitions": [{
+        "id": "match",
+        "description": prompt,
+        "fields": [{
+          "name": "relevant",
+          "type": "boolean",
+          "description": "true when this segment matches: " & prompt,
+        }],
+      }],
+    },
+  })
+  let task = curlJson(key, [apiBase & "/analyze/tasks",
+    "-H", "Content-Type: application/json", "-d", body])
+  let taskId = task{"task_id"}.getStr
+  if taskId == "":
+    error "pegasus: segmentation task was not created."
+
+  for _ in 0 ..< (maxPollSeconds div pollSeconds):
+    let resp = curlJson(key, [apiBase & "/analyze/tasks/" & taskId])
+    case resp{"status"}.getStr
+    of "ready":
+      # result.data is itself a JSON-encoded string of the segments.
+      let dataStr = resp{"result"}{"data"}.getStr
+      try:
+        return parseJson(dataStr)
+      except JsonParsingError:
+        error "pegasus: could not parse segmentation result."
+    of "failed":
+      error "pegasus: segmentation task failed."
+    else:
+      conwrite "Analyzing with Pegasus"
+      sleep(pollSeconds * 1000)
+  error "pegasus: timed out waiting for the segmentation result."
+
+proc pegasus*(path: string, tb: AVRational, prompt: string, minSeg: float,
+    lengthHint: int): seq[bool] =
+  ## Return a per-timebase mask where `true` marks spans Pegasus reports as
+  ## matching `prompt`. `lengthHint` is the timeline length so the mask covers
+  ## the whole media even when the final segment is short.
+  if prompt == "":
+    error "pegasus: a prompt is required (--pegasus-prompt \"...\")."
+
+  let key = apiKey()
+  let assetId = uploadAsset(key, path)
+  let segments = runSegmentation(key, assetId, prompt, minSeg){"match"}
+
+  var spans: seq[(int, int)]
+  var length = lengthHint
+  if segments.kind == JArray:
+    for seg in segments:
+      # A segment counts as a match when its `relevant` field is true. Snap the
+      # span outward (floor start, ceil end) so a partially-covered frame is
+      # kept, matching the subtitle analyzer's convention.
+      if not seg{"metadata"}{"relevant"}.getBool(true):
+        continue
+      let
+        startF = seg{"start_time"}.getFloat
+        endF = seg{"end_time"}.getFloat
+        s = floor(startF * tb).int
+        e = ceil(endF * tb).int
+      length = max(length, e)
+      spans.add((s, e))
+
+  result = newSeq[bool](max(length, 0))
+  for (s, e) in spans:
+    for i in max(s, 0) ..< min(e, result.len):
+      result[i] = true

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -136,6 +136,10 @@ Examples:
   OptDef(names: "--yt-dlp-extras", c: cUrl, datum: "yt-dlp-extras", metavar: "CMD",
     help: "Add extra options for yt-dlp. Must be in quotes"),
 
+  OptDef(names: "--pegasus-prompt", c: cEdit, datum: "pegasus-prompt", metavar: "TEXT",
+    help: "Natural-language prompt for `--edit pegasus`. Use this for multi-word " &
+          "prompts, since `--edit` tokens cannot contain spaces. Must be in quotes"),
+
   OptDef(names: "--progress", c: cDis, datum: "progress", metavar: "PROGRESS",
     help: "Set what type of progress bar to use"),
   OptDef(names: "--debug", c: cDis, kind: Flag, datum: "isDebug",

--- a/src/edit.nim
+++ b/src/edit.nim
@@ -1,6 +1,6 @@
 import std/[math, options, os, sequtils, strformat, strutils]
 import ./[av, editlexer, editmethods, ffmpeg, log]
-import ./analyze/[audio, blackdetect, motion, subtitle]
+import ./analyze/[audio, blackdetect, motion, pegasus, subtitle]
 import ./util/[bar, dnorm16, fun, rational]
 
 import ./vendor/tinyre/tinyre
@@ -319,6 +319,33 @@ proc interpretEdit*(args: mainArgs, container: InputContainer, input: string, tb
 
         result.orWithThreshold(blackdetect(bar, container, input, tb, stream, pixelBlack), threshold)
         return result
+      of "pegasus":
+        let argOrder = argOrderOf("pegasus")
+        # `--edit` tokens can't contain spaces, so a multi-word prompt comes from
+        # `--pegasus-prompt`. The inline `pegasus:token` form still works for a
+        # single-token prompt and, when both are set, is overridden by the flag.
+        var prompt = args.pegasusPrompt
+        var minSeg: float = 4.0
+
+        for expr in node[1 ..< node.len]:
+          let val = parseColFunc(argPos, isKey, argOrder, expr, text)
+          case argPos:
+          of 0:
+            if prompt == "":
+              prompt = val
+          of 1: minSeg = parseFloatInRange(val, 2.0, 3600.0)
+          else: error "Too many args"
+
+          if not isKey:
+            argPos += 1
+
+        if prompt == "":
+          error "pegasus: a prompt is required. Pass one with " &
+            "--pegasus-prompt \"...\" (recommended for multi-word prompts)."
+
+        let length = mediaLength(container)
+        let tbLength = (round((length * tb).float64)).int
+        return pegasus(input, tb, prompt, minSeg, tbLength)
       of "subtitle", "regex":
         let argOrder = argOrderOf("subtitle")
         var pattern = ""

--- a/src/editmethods.nim
+++ b/src/editmethods.nim
@@ -49,6 +49,14 @@ const editMethodDefs*: seq[EditMethodDef] = @[
     help: "Mark a frame as loud when at least `threshold` of its pixels are " &
           "black, where a pixel counts as black when its grayscale luma is at " &
           "or below `pixel-black`. Wrap in `not` to instead cut black frames."),
+  EditMethodDef(names: @["pegasus"], media: emVideo,
+    params: @[p("prompt", "String"),
+              p("min-segment", "Float", "4.0")],
+    help: "Content-aware editing with TwelveLabs Pegasus. Upload the video and " &
+          "ask the model, in plain language via `prompt`, which moments to " &
+          "keep; matching time spans become loud. `min-segment` is the minimum " &
+          "segment length in seconds. Requires the TWELVELABS_API_KEY env var; " &
+          "get a free key at https://twelvelabs.io."),
   EditMethodDef(names: @["subtitle", "regex"], media: emSubtitle,
     params: @[p("pattern", "String"),
               p("stream", "Natural", "0"),

--- a/src/log.nim
+++ b/src/log.nim
@@ -69,6 +69,7 @@ type mainArgs* = object
   whenActive*: Actions = aNil
   labeledEdits*: seq[tuple[label: int, expr: string]]
   labeledWhens*: seq[tuple[label: int, action: Actions]]
+  pegasusPrompt*: string  # natural-language prompt for `--edit pegasus`
   `export`*: string = ""
   output*: string = ""
   setAction*: seq[(Actions, PackedInt, PackedInt)]

--- a/src/main.nim
+++ b/src/main.nim
@@ -459,6 +459,8 @@ judge making cuts.
       args.outputFormat = key
     of "yt-dlp-extras":
       args.ytDlpExtras = key
+    of "pegasus-prompt":
+      args.pegasusPrompt = key
     of "scale":
       args.scale = parseNum(key, expecting)
     of "resolution":


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds a new `--edit pegasus` method that brings *content-aware* cuts to auto-editor. Instead of reacting to low-level signal energy like `audio` and `motion`, it asks [TwelveLabs](https://twelvelabs.io) Pegasus (a video-understanding model) a plain-language question about the footage and keeps the time spans that match.

```sh
# Keep only the parts where someone is speaking on camera.
auto-editor example.mp4 --edit pegasus --pegasus-prompt "a person is speaking to the camera"

# Layer it on top of the audio heuristic.
auto-editor example.mp4 --edit "(or audio:0.04 pegasus)" --pegasus-prompt "an exciting action moment"
```

**Why it helps this project:** loudness and motion are great proxies, but they can't tell *what* is on screen. Pegasus lets users cut on semantics ("keep the demo", "drop the intro card", "only the goals") — a capability that composes with the existing `or`/`and`/`not` operators and labels rather than replacing anything.

**How it works:** the input file is uploaded to TwelveLabs as an asset, analyzed with Pegasus 1.5 in `time_based_metadata` mode against the prompt, and the returned matching segments are rasterized onto the timebase exactly like the existing `subtitle` analyzer does. It slots into the same `editMethodDefs` registry and `interpretEdit` dispatch as every other method, so the docs generator and `editNeeds` pick it up for free.

**Opt-in / non-breaking:**
- Nothing runs unless `pegasus` appears in `--edit`. Defaults are unchanged.
- No new build- or link-time dependency. Network calls shell out to `curl` (mirroring how `main.nim` already shells out to `yt-dlp`), so there's no SSL-linked `std/httpclient` to thread through the static-link build.
- Auth is read from the `TWELVELABS_API_KEY` env var; the key is passed to curl as an argument (no shell expansion, never logged).
- A `--pegasus-prompt` flag carries the natural-language prompt, since `--edit` tokens can't contain spaces (the inline `pegasus:token` form still works for a single token).

**Testing:**
- `nim check --cpu:i386 --hints:off src/main.nim` (the smoke.yml gate) passes with the change wired in through `edit.nim` → `analyze/pegasus.nim`.
- The TwelveLabs request/response wiring was verified end-to-end against the live v1.3 API: uploading this repo's `example.mp4`, running a `time_based_metadata` segmentation, and parsing the returned segments into the keep/cut mask. The code replicates those exact request and response shapes.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
