### PR TITLE
Link parakeet in the dynamic pkg-config build

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -20,8 +20,8 @@ when defined(dynamic):
   if ffmpegLibs.exitCode == 0:
     switch("passL", ffmpegLibs.output.strip())
 
-  let whisperCflags = gorgeEx("pkg-config --cflags whisper ggml", "")
-  let whisperLibs = gorgeEx("pkg-config --libs whisper ggml", "")
+  let whisperCflags = gorgeEx("pkg-config --cflags whisper parakeet ggml", "")
+  let whisperLibs = gorgeEx("pkg-config --libs whisper parakeet ggml", "")
   if enableWhisper and whisperCflags.exitCode == 0 and whisperLibs.exitCode == 0:
     switch("define", "whisper")
     switch("passC", whisperCflags.output.strip())


### PR DESCRIPTION
The static link path adds -lparakeet, but the dynamic path (used when building against a system whisper.cpp via pkg-config, e.g. Homebrew) only queried "whisper ggml". Since whisper.cpp installs parakeet as a separate parakeet.pc, -lparakeet was dropped and linking failed with undefined symbol parakeet_token_to_str.